### PR TITLE
Order purchase list by date

### DIFF
--- a/Controller/EditRegularizacionImpuesto.php
+++ b/Controller/EditRegularizacionImpuesto.php
@@ -252,12 +252,12 @@ class EditRegularizacionImpuesto extends EditController
      * @param BaseView $view
      * @param int      $group
      */
-    protected function getListPartidaImpuesto($view, $group)
+    protected function getListPartidaImpuesto($view, $group, $orderby)
     {
         $id = $this->getViewModelValue('EditRegularizacionImpuesto', 'idregiva');
         if (!empty($id)) {
             $where = $this->getPartidaImpuestoWhere($group);
-            $view->loadData(false, $where, ['partidas.codserie' => 'ASC', 'partidas.factura' => 'ASC']);
+            $view->loadData(false, $where, $orderby);
         }
     }
 
@@ -328,11 +328,19 @@ class EditRegularizacionImpuesto extends EditController
                 break;
 
             case 'ListPartidaImpuesto-1':
-                $this->getListPartidaImpuesto($view, SubAccountTools::SPECIAL_GROUP_TAX_INPUT);
+                $this->getListPartidaImpuesto(
+                    $view,
+                    SubAccountTools::SPECIAL_GROUP_TAX_INPUT,
+                    ['facturasprov.fecha' => 'ASC', 'facturasprov.hora' => 'ASC']
+                );
                 break;
 
             case 'ListPartidaImpuesto-2':
-                $this->getListPartidaImpuesto($view, SubAccountTools::SPECIAL_GROUP_TAX_OUTPUT);
+                $this->getListPartidaImpuesto(
+                    $view,
+                    SubAccountTools::SPECIAL_GROUP_TAX_OUTPUT,
+                    ['partidas.codserie' => 'ASC', 'partidas.factura' => 'ASC']
+                );
                 break;
         }
     }

--- a/Model/Join/PartidaImpuesto.php
+++ b/Model/Join/PartidaImpuesto.php
@@ -25,7 +25,7 @@ use FacturaScripts\Core\Model\Base\JoinModel;
  *
  * @author Artex Trading sa     <jcuello@artextrading.com>
  * @author Carlos García Gómez  <carlos@facturascripts.com>
- * 
+ *
  * @property float $baseimponible
  * @property float $cuotaiva
  * @property float $cuotarecargo
@@ -69,7 +69,9 @@ class PartidaImpuesto extends JoinModel
             'idpartida' => 'partidas.idpartida',
             'iva' => 'partidas.iva',
             'numero' => 'asientos.numero',
-            'recargo' => 'partidas.recargo'
+            'recargo' => 'partidas.recargo',
+            'fechafactura' => 'COALESCE(facturasprov.fecha, facturascli.fecha)',
+            'horafactura' => 'COALESCE(facturasprov.hora, facturascli.hora)',
         ];
     }
 
@@ -81,7 +83,9 @@ class PartidaImpuesto extends JoinModel
         return 'asientos'
             . ' INNER JOIN partidas ON partidas.idasiento = asientos.idasiento'
             . ' INNER JOIN subcuentas ON subcuentas.idsubcuenta = partidas.idsubcuenta'
-            . ' INNER JOIN cuentas ON cuentas.idcuenta = subcuentas.idcuenta';
+            . ' INNER JOIN cuentas ON cuentas.idcuenta = subcuentas.idcuenta'
+            . ' LEFT JOIN facturasprov ON facturasprov.idasiento = asientos.idasiento'
+            . ' LEFT JOIN facturascli ON facturascli.idasiento = asientos.idasiento';
     }
 
     /**
@@ -93,7 +97,9 @@ class PartidaImpuesto extends JoinModel
             'asientos',
             'partidas',
             'subcuentas',
-            'cuentas'
+            'cuentas',
+            'facturasprov',
+            'facturascli',
         ];
     }
 

--- a/XMLView/ListPartidaImpuesto.xml
+++ b/XMLView/ListPartidaImpuesto.xml
@@ -45,13 +45,16 @@
         <column name="invoice" order="110">
             <widget type="text" fieldname="factura" />
         </column>
+        <column name="invoice-date" order="115" display="center">
+            <widget type="date" fieldname="fechafactura" />
+        </column>
         <column name="accounting-entry" order="120">
             <widget type="text" fieldname="numero" />
         </column>
         <column name="document" order="130" display="none">
             <widget type="text" fieldname="documento" />
         </column>
-        <column name="date" order="140" display="none">
+        <column name="accounting-date" order="140" display="none">
             <widget type="date" fieldname="fecha" />
         </column>
         <column name="subaccount" order="150" display="none">


### PR DESCRIPTION
The purchase tax list is now ordered by the date and time of the purchase invoice instead of the series and document number.