### PR TITLE
Order purchase taxes list by date

### DIFF
--- a/Controller/EditRegularizacionImpuesto.php
+++ b/Controller/EditRegularizacionImpuesto.php
@@ -31,7 +31,7 @@ use FacturaScripts\Dinamic\Model\RegularizacionImpuesto;
  * Controller to list the items in the RegularizacionImpuesto model
  *
  * @author Carlos García Gómez          <carlos@facturascripts.com>
- * @author Artex Trading sa             <jcuello@artextrading.com>
+ * @author Jose Antonio Cuello Principal <yopli2000@gmail.com>
  * @author Cristo M. Estévez Hernández  <cristom.estevez@gmail.com>
  */
 class EditRegularizacionImpuesto extends EditController
@@ -251,13 +251,14 @@ class EditRegularizacionImpuesto extends EditController
      *
      * @param BaseView $view
      * @param int      $group
+     * @param string   $orderby
      */
-    protected function getListPartidaImpuesto($view, $group)
+    protected function getListPartidaImpuesto($view, $group, $orderby)
     {
         $id = $this->getViewModelValue('EditRegularizacionImpuesto', 'idregiva');
         if (!empty($id)) {
             $where = $this->getPartidaImpuestoWhere($group);
-            $view->loadData(false, $where, ['partidas.codserie' => 'ASC', 'partidas.factura' => 'ASC']);
+            $view->loadData(false, $where, $orderby);
         }
     }
 
@@ -328,11 +329,19 @@ class EditRegularizacionImpuesto extends EditController
                 break;
 
             case 'ListPartidaImpuesto-1':
-                $this->getListPartidaImpuesto($view, SubAccountTools::SPECIAL_GROUP_TAX_INPUT);
+                $this->getListPartidaImpuesto(
+                    $view,
+                    SubAccountTools::SPECIAL_GROUP_TAX_INPUT,
+                    ['asientos.fecha' => 'ASC', 'partidas.codserie' => 'ASC', 'partidas.factura' => 'ASC']
+                );
                 break;
 
             case 'ListPartidaImpuesto-2':
-                $this->getListPartidaImpuesto($view, SubAccountTools::SPECIAL_GROUP_TAX_OUTPUT);
+                $this->getListPartidaImpuesto(
+                    $view,
+                    SubAccountTools::SPECIAL_GROUP_TAX_OUTPUT,
+                    ['partidas.codserie' => 'ASC', 'partidas.factura' => 'ASC']
+                );
                 break;
         }
     }

--- a/Lib/Accounting/VatRegularizationToAccounting.php
+++ b/Lib/Accounting/VatRegularizationToAccounting.php
@@ -30,7 +30,7 @@ use FacturaScripts\Dinamic\Model\Subcuenta;
  * Class for the accounting of tax regularizations
  *
  * @author Carlos García Gómez  <carlos@facturascripts.com>
- * @author Artex Trading sa     <jcuello@artextrading.com>
+ * @author Jose Antonio Cuello Principal <yopli2000@gmail.com>
  */
 class VatRegularizationToAccounting extends AccountingClass
 {

--- a/Model/Join/PartidaImpuesto.php
+++ b/Model/Join/PartidaImpuesto.php
@@ -23,9 +23,9 @@ use FacturaScripts\Core\Model\Base\JoinModel;
 /**
  * Auxiliary model to load a list of accounting entries with VAT
  *
- * @author Artex Trading sa     <jcuello@artextrading.com>
+ * @author Jose Antonio Cuello Principal <yopli2000@gmail.com>
  * @author Carlos García Gómez  <carlos@facturascripts.com>
- * 
+ *
  * @property float $baseimponible
  * @property float $cuotaiva
  * @property float $cuotarecargo

--- a/Model/Join/PartidaImpuestoResumen.php
+++ b/Model/Join/PartidaImpuestoResumen.php
@@ -23,9 +23,9 @@ use FacturaScripts\Core\Model\Base\JoinModel;
 /**
  * Auxiliary model to load a resume of accounting entries with VAT
  *
- * @author Artex Trading sa     <jcuello@artextrading.com>
+ * @author Jose Antonio Cuello Principal <yopli2000@gmail.com>
  * @author Carlos García Gómez  <carlos@facturascripts.com>
- * 
+ *
  * @property float  $baseimponible
  * @property string $codcuentaesp
  * @property string $codejercicio

--- a/XMLView/EditRegularizacionImpuesto.xml
+++ b/XMLView/EditRegularizacionImpuesto.xml
@@ -16,7 +16,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  *
- * @author Artex Trading sa     <jcuello@artextrading.com>
+ * @author Jose Antonio Cuello Principal <yopli2000@gmail.com>
  * @author Carlos García Gómez  <carlos@facturascripts.com>
 -->
 <view>

--- a/XMLView/ListPartidaImpuesto.xml
+++ b/XMLView/ListPartidaImpuesto.xml
@@ -17,7 +17,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  *
  * @author Carlos García Gómez  <carlos@facturascripts.com>
- * @author Artex Trading sa     <jcuello@artextrading.com>
+ * @author Jose Antonio Cuello Principal <yopli2000@gmail.com>
 -->
 <view>
     <columns>
@@ -51,7 +51,7 @@
         <column name="document" order="130" display="none">
             <widget type="text" fieldname="documento" />
         </column>
-        <column name="date" order="140" display="none">
+        <column name="date" order="140" display="center">
             <widget type="date" fieldname="fecha" />
         </column>
         <column name="subaccount" order="150" display="none">

--- a/XMLView/ListPartidaImpuestoResumen.xml
+++ b/XMLView/ListPartidaImpuestoResumen.xml
@@ -17,7 +17,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  *
  * @author Carlos García Gómez  <carlos@facturascripts.com>
- * @author Artex Trading sa     <jcuello@artextrading.com>
+ * @author Jose Antonio Cuello Principal <yopli2000@gmail.com>
 -->
 <view>
     <columns>

--- a/XMLView/ListRegularizacionImpuesto.xml
+++ b/XMLView/ListRegularizacionImpuesto.xml
@@ -16,7 +16,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  *
- * @author Artex Trading sa     <jcuello@artextrading.com>
+ * @author Jose Antonio Cuello Principal <yopli2000@gmail.com>
  * @author Carlos García Gómez  <carlos@facturascripts.com>
 -->
 <view>


### PR DESCRIPTION
The purchase tax list is now ordered by the date and time of the purchase invoice instead of the series and document number.