### PR TITLE
Mostrar el nombre de la subcuenta en vez del nombre de la cuenta especial

### DIFF
--- a/Model/Join/PartidaImpuestoResumen.php
+++ b/Model/Join/PartidaImpuestoResumen.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * This file is part of Modelo303 plugin for FacturaScripts
- * Copyright (C) 2017-2022 Carlos Garcia Gomez <carlos@facturascripts.com>
+ * Copyright (C) 2017-2024 Carlos Garcia Gomez <carlos@facturascripts.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -68,7 +68,7 @@ class PartidaImpuestoResumen extends JoinModel
             'codcuentaesp' => 'COALESCE(subcuentas.codcuentaesp, cuentas.codcuentaesp)',
             'codejercicio' => 'asientos.codejercicio',
             'codsubcuenta' => 'partidas.codsubcuenta',
-            'descripcion' => 'cuentasesp.descripcion',
+            'descripcion' => 'subcuentas.descripcion',
             'idsubcuenta' => 'partidas.idsubcuenta',
             'iva' => 'partidas.iva',
             'recargo' => 'partidas.recargo'


### PR DESCRIPTION
Al mostrar el resumen del modelo, siempre aparece repetido el nombre de la cuenta especial, y quizás lo correcto es que aparezca el nombre de cada una de las cuentas, así que cada más claro lo que es cada una.

Antes
![1710522535_captura1](https://github.com/FacturaScripts/modelo303/assets/13066282/488150cf-d01f-42f4-8774-c33b6c6e4b6e)

Ahora
![Captura desde 2024-04-11 09-07-23](https://github.com/FacturaScripts/modelo303/assets/13066282/016085fd-5be2-4234-98cf-bab4858f063a)