### PR TITLE
 Tarea #3353 - comprobar que se tiene en cuenta fecha devengo facturas

### DIFF
--- a/Test/main/ComprobarFechaDevengoTest.php
+++ b/Test/main/ComprobarFechaDevengoTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace FacturaScripts\Test\Plugins;
+
+use FacturaScripts\Core\Base\DataBase\DataBaseWhere;
+use FacturaScripts\Core\Model\FacturaCliente;
+use FacturaScripts\Core\Tools;
+use FacturaScripts\Plugins\Modelo303\Model\Join\PartidaImpuestoResumen;
+use FacturaScripts\Test\Traits\RandomDataTrait;
+
+class ComprobarFechaDevengoTest extends Modelo303TestCase
+{
+    use RandomDataTrait;
+
+    /**
+     * El plugin filtra por la fecha del asiento.
+     * La fecha del asiento se asigna primero si existe la fecha de devengo
+     * y si no existe por la fecha de la factura.
+     *
+     * @return void
+     */
+    public function testComprobarFechaDevengo()
+    {
+        $invoiceFechaHoy = $this->getRandomCustomerInvoice();
+
+        // creamos una factura con fecha de devengo anterior
+        $invoiceFechaDevengoAnterior = $this->getRandomCustomerInvoice();
+        $invoiceFechaDevengoAnterior->fechadevengo = Tools::date('-1 month');
+        $this->assertTrue($invoiceFechaDevengoAnterior->save());
+
+        // creamos una factura con fecha de devengo posterior
+        $invoiceFechaDevengoPosterior = $this->getRandomCustomerInvoice();
+        $invoiceFechaDevengoPosterior->fechadevengo = Tools::date('+1 month');
+        $this->assertTrue($invoiceFechaDevengoPosterior->save());
+
+        // comprobamos que calcula filtrando por la fecha de devengo de las facturas
+
+        // comprobamos que solo obtiene los resultados de la factura de hoy
+        $partidaImpuestoResumen = new PartidaImpuestoResumen();
+        $partida = $partidaImpuestoResumen->all([
+            new DataBaseWhere('COALESCE(subcuentas.codcuentaesp, cuentas.codcuentaesp)', 'IVAREP'),
+            new DataBaseWhere('fecha', Tools::date()),
+        ])[0];
+        $this->assertEquals($invoiceFechaHoy->totaliva, $partida->cuotaiva);
+        $this->assertEquals($invoiceFechaHoy->totaliva, $partida->haber);
+
+        // comprobamos que solo obtiene los resultados de la factura de fecha anterior
+        $partidaImpuestoResumen = new PartidaImpuestoResumen();
+        $partida = $partidaImpuestoResumen->all([
+            new DataBaseWhere('COALESCE(subcuentas.codcuentaesp, cuentas.codcuentaesp)', 'IVAREP'),
+            new DataBaseWhere('fecha', Tools::date('-1 month')),
+        ])[0];
+        $this->assertEquals($invoiceFechaDevengoAnterior->totaliva, $partida->cuotaiva);
+        $this->assertEquals($invoiceFechaDevengoAnterior->totaliva, $partida->haber);
+
+        // comprobamos que solo obtiene los resultados de la factura de fecha posterior
+        $partidaImpuestoResumen = new PartidaImpuestoResumen();
+        $partida = $partidaImpuestoResumen->all([
+            new DataBaseWhere('COALESCE(subcuentas.codcuentaesp, cuentas.codcuentaesp)', 'IVAREP'),
+            new DataBaseWhere('fecha', Tools::date('+1 month')),
+        ])[0];
+        $this->assertEquals($invoiceFechaDevengoPosterior->totaliva, $partida->cuotaiva);
+        $this->assertEquals($invoiceFechaDevengoPosterior->totaliva, $partida->haber);
+
+        // comprobamos que solo obtiene los resultados de todas las facturas
+        $totalIVAFacturasCliente = FacturaCliente::table()->sum('totaliva');
+
+        $partidaImpuestoResumen = new PartidaImpuestoResumen();
+        $partida = $partidaImpuestoResumen->all([
+            new DataBaseWhere('COALESCE(subcuentas.codcuentaesp, cuentas.codcuentaesp)', 'IVAREP'),
+        ])[0];
+        $this->assertEquals($totalIVAFacturasCliente, $partida->cuotaiva);
+        $this->assertEquals($totalIVAFacturasCliente, $partida->haber);
+    }
+}

--- a/Test/main/Modelo303TestCase.php
+++ b/Test/main/Modelo303TestCase.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace FacturaScripts\Test\Plugins;
+
+use FacturaScripts\Core\Model\User;
+use FacturaScripts\Test\Traits\DefaultSettingsTrait;
+use FacturaScripts\Test\Traits\LogErrorsTrait;
+use PHPUnit\Framework\TestCase;
+
+class Modelo303TestCase extends TestCase
+{
+    use DefaultSettingsTrait;
+    use LogErrorsTrait;
+
+    public function setUp(): void
+    {
+        // inicializamos los modelos para que se creen las
+        // tablas necesarias y no de error de Foreign Key
+        new User();
+        foreach (['Factura', 'Albaran', 'Presupuesto', 'Pedido'] as $doc) {
+            foreach (['Cliente', 'Proveedor'] as $subject) {
+                $className = '\\FacturaScripts\\Dinamic\\Model\\' . $doc . $subject;
+                new $className();
+            }
+        }
+
+        self::setDefaultSettings();
+        self::installAccountingPlan();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->logErrors();
+    }
+}

--- a/Test/main/VatRegularizationToAccountingTest.php
+++ b/Test/main/VatRegularizationToAccountingTest.php
@@ -24,9 +24,8 @@ use FacturaScripts\Plugins\Modelo303\Lib\Accounting\VatRegularizationToAccountin
 use FacturaScripts\Test\Traits\DefaultSettingsTrait;
 use FacturaScripts\Test\Traits\LogErrorsTrait;
 use FacturaScripts\Test\Traits\RandomDataTrait;
-use PHPUnit\Framework\TestCase;
 
-final class VatRegularizationToAccountingTest extends TestCase
+final class VatRegularizationToAccountingTest extends Modelo303TestCase
 {
     use DefaultSettingsTrait;
     use LogErrorsTrait;
@@ -41,14 +40,14 @@ final class VatRegularizationToAccountingTest extends TestCase
     public function testCreate()
     {
         // creamos una factura de proveedor
-        $supplierInvoice = $this->getRandomSupplierInvoice('10-01-2022');
+        $supplierInvoice = $this->getRandomSupplierInvoice('now');
         $this->assertTrue($supplierInvoice->save());
 
         // creamos dos facturas de cliente
-        $customerInvoice1 = $this->getRandomCustomerInvoice('11-01-2022');
+        $customerInvoice1 = $this->getRandomCustomerInvoice('+1 day');
         $this->assertTrue($customerInvoice1->save());
 
-        $customerInvoice2 = $this->getRandomCustomerInvoice('12-01-2022');
+        $customerInvoice2 = $this->getRandomCustomerInvoice('+2 day');
         $this->assertTrue($customerInvoice2->save());
 
         // creamos una regularización


### PR DESCRIPTION
Se ha verificado que el plugin considera la fecha de devengo al procesar los informes.

En concreto, el plugin filtra por la fecha del asiento contable, y esta fecha se determina de la siguiente forma:

    Si la factura tiene fecha de devengo, se utiliza esa como fecha del asiento.

    Si no tiene fecha de devengo, se usa la fecha de la factura.

Por tanto, el filtrado siempre se realiza en función de una fecha válida, ya sea la de devengo (si existe) o la de la factura.

- Se añaden tests para comprobar esta situación.