### PR TITLE
feat: add tax settlement summary to PDF export

### DIFF
--- a/Controller/EditRegularizacionImpuesto.php
+++ b/Controller/EditRegularizacionImpuesto.php
@@ -186,8 +186,55 @@ class EditRegularizacionImpuesto extends EditController
 
     protected function exportAction(): void
     {
+        if (false === $this->views[$this->active]->settings['btnPrint'] ||
+            false === $this->permissions->allowExport) {
+            Tools::log()->warning('no-print-permission');
+            return;
+        }
+
+        $this->setTemplate(false);
         $this->exportManager->setOrientation('landscape');
-        parent::exportAction();
+        $this->exportManager->newDoc(
+            $this->request->queryOrInput('option', ''),
+            $this->title,
+            (int)$this->request->input('idformat', ''),
+            $this->request->input('langcode', '')
+        );
+
+        // load data for all views before exporting
+        foreach ($this->views as $name => $view) {
+            $this->loadData($name, $view);
+        }
+
+        foreach ($this->views as $name => $selectedView) {
+            if (false === $selectedView->settings['active']) {
+                continue;
+            }
+
+            $activeTab = $this->request->inputOrQuery('activetab', '');
+            if (!empty($activeTab) && $activeTab !== $name) {
+                continue;
+            }
+
+            $codes = $this->request->request->getArray('codes');
+            if (false === $selectedView->export($this->exportManager, $codes)) {
+                break;
+            }
+        }
+
+        // add tax settlement summary table
+        if (!empty($this->modelo303)) {
+            $concept = Tools::trans('concept');
+            $amount = Tools::trans('amount');
+            $rows = [
+                [$concept => Tools::trans('total-accrued-fee'), $amount => Tools::money($this->modelo303['27'])],
+                [$concept => Tools::trans('total-to-deduct'), $amount => Tools::money($this->modelo303['45'])],
+                [$concept => Tools::trans('total-result-of-the-general-regime'), $amount => Tools::money($this->modelo303['46'])],
+            ];
+            $this->exportManager->addTablePage([$concept, $amount], $rows);
+        }
+
+        $this->exportManager->show($this->response);
     }
 
     protected function getListPartida(BaseView $view): void


### PR DESCRIPTION
## Summary

- The PDF export currently only includes the accounting entry data but **not the tax settlement summary** (accrued VAT, deductible VAT, general regime result) that is displayed in the web interface via the `Modelo303.html.twig` template.
- Since `HtmlView` does not export its content to PDF, the summary (boxes 27, 45 and 46) was completely missing from the exported document.
- Override `exportAction()` to manually load `modelo303` data and append a summary table with the settlement totals after the standard view export.

## Changes

**Modified:** `Controller/EditRegularizacionImpuesto.php`

The overridden `exportAction()`:
1. Replicates the parent `EditController::exportAction()` logic
2. Loads view data before exporting (needed because `exportAction` runs in `execPreviousAction`, before `loadData` is called)
3. After exporting all views, adds a table with:
   - **Box 27** — Total accrued fee (total cuota devengada)
   - **Box 45** — Total to deduct (total a deducir)
   - **Box 46** — General regime result (resultado régimen general)

## Test plan

- [ ] Open an existing tax regularization (Modelo 303) with data
- [ ] Click the print/export PDF button
- [ ] Verify the PDF now includes a summary table with boxes 27, 45 and 46
- [ ] Verify the amounts match those shown in the web interface

🤖 Generated with [Claude Code](https://claude.com/claude-code)