### PR TITLE
Refactorización de filtros en el plugin Modelo303

### DIFF
--- a/Controller/EditRegularizacionImpuesto.php
+++ b/Controller/EditRegularizacionImpuesto.php
@@ -20,7 +20,6 @@
 namespace FacturaScripts\Plugins\Modelo303\Controller;
 
 use Exception;
-use FacturaScripts\Core\Base\DataBase\DataBaseWhere;
 use FacturaScripts\Core\DataSrc\Impuestos;
 use FacturaScripts\Core\DataSrc\Series;
 use FacturaScripts\Core\Lib\ExtendedController\BaseView;
@@ -285,16 +284,16 @@ class EditRegularizacionImpuesto extends EditController
             case 'ListPartidaImpuestoResumen':
                 $mainModel = $this->getModel();
                 $where = [
-                    new DataBaseWhere('partidas.codsubcuenta', '477%', 'LIKE'),
-                    new DataBaseWhere('partidas.codsubcuenta', '472%', 'LIKE', 'OR'),
-                    new DataBaseWhere('asientos.idempresa', $mainModel->idempresa),
-                    new DataBaseWhere('asientos.fecha', $mainModel->fechainicio, '>='),
-                    new DataBaseWhere('asientos.fecha', $mainModel->fechafin, '<='),
-                    new DataBaseWhere('COALESCE(series.siniva, false)', false),
+                    Where::like('partidas.codsubcuenta', '477%'),
+                    Where::orLike('partidas.codsubcuenta', '472%'),
+                    Where::eq('asientos.idempresa', $mainModel->idempresa),
+                    Where::gte('asientos.fecha', $mainModel->fechainicio),
+                    Where::lte('asientos.fecha', $mainModel->fechafin),
+                    Where::eq('COALESCE(series.siniva, false)', false),
                 ];
 
                 if (false === empty($mainModel->idasiento)) {
-                    $where[] = new DataBaseWhere('partidas.idasiento', $mainModel->idasiento, '<>');
+                    $where[] = Where::notEq('partidas.idasiento', $mainModel->idasiento);
                 }
                 $view->loadData(false, $where, [
                     'COALESCE(subcuentas.codcuentaesp, cuentas.codcuentaesp)' => 'ASC',
@@ -344,7 +343,7 @@ class EditRegularizacionImpuesto extends EditController
     private function getListPartida(BaseView $view): void
     {
         if (false === empty($this->getModel()->idasiento)) {
-            $where = [new DataBaseWhere('idasiento', $this->getModel()->idasiento)];
+            $where = [Where::eq('idasiento', $this->getModel()->idasiento)];
             $view->loadData(false, $where, ['orden' => 'ASC']);
         }
     }
@@ -369,10 +368,8 @@ class EditRegularizacionImpuesto extends EditController
     }
 
     /**
-     * Get DataBaseWhere filter for tax group
-     *
      * @param int $group
-     * @return DataBaseWhere[]
+     * @return array
      */
     private function getPartidaImpuestoWhere(int $group): array
     {
@@ -386,13 +383,13 @@ class EditRegularizacionImpuesto extends EditController
 
         $subAccountTools = new SubAccountTools();
         return [
-            new DataBaseWhere('asientos.idasiento', implode(',', $ids), 'NOT IN'),
-            new DataBaseWhere('asientos.codejercicio', $this->getModel()->codejercicio),
-            new DataBaseWhere('asientos.fecha', $this->getModel()->fechainicio, '>='),
-            new DataBaseWhere('asientos.fecha', $this->getModel()->fechafin, '<='),
-            new DataBaseWhere('COALESCE(series.siniva, 0)', 0),
-            new DataBaseWhere('partidas.baseimponible', 0, '!='),
-            new DataBaseWhere('COALESCE(partidas.iva, 0)', 0, '>', 'OR'),
+            Where::notIn('asientos.idasiento', $ids),
+            Where::eq('asientos.codejercicio', $this->getModel()->codejercicio),
+            Where::gte('asientos.fecha', $this->getModel()->fechainicio),
+            Where::lte('asientos.fecha', $this->getModel()->fechafin),
+            Where::eq('COALESCE(series.siniva, 0)', 0),
+            Where::notEq('partidas.baseimponible', 0),
+            Where::orGt('COALESCE(partidas.iva, 0)', 0),
             $subAccountTools->whereForSpecialAccounts('COALESCE(subcuentas.codcuentaesp, cuentas.codcuentaesp)', $group)
         ];
     }

--- a/Controller/ListRegularizacionImpuesto.php
+++ b/Controller/ListRegularizacionImpuesto.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * This file is part of Modelo303 plugin for FacturaScripts
- * Copyright (C) 2017-2024 Carlos Garcia Gomez <carlos@facturascripts.com>
+ * Copyright (C) 2017-2026 Carlos Garcia Gomez <carlos@facturascripts.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -19,8 +19,8 @@
 
 namespace FacturaScripts\Plugins\Modelo303\Controller;
 
-use FacturaScripts\Core\Base\DataBase\DataBaseWhere;
 use FacturaScripts\Core\DataSrc\Empresas;
+use FacturaScripts\Core\Where;
 use FacturaScripts\Core\Lib\ExtendedController\ListController;
 use FacturaScripts\Core\Tools;
 
@@ -67,7 +67,7 @@ class ListRegularizacionImpuesto extends ListController
             ->addFilterSelect('idempresa', 'company', 'idempresa', Empresas::codeModel())
             ->addFilterSelect('codejercicio', 'exercise', 'codejercicio', $exercises)
             ->addFilterSelectWhere('status', [
-                ['label' => Tools::lang()->trans('model-303'), 'where' => [new DataBaseWhere('periodo', 'Y', '!=')]]
+                ['label' => Tools::lang()->trans('model-303'), 'where' => [Where::notEq('periodo', 'Y')]]
             ]);
     }
 
@@ -89,7 +89,7 @@ class ListRegularizacionImpuesto extends ListController
             ->addFilterSelect('idempresa', 'company', 'idempresa', Empresas::codeModel())
             ->addFilterSelect('codejercicio', 'exercise', 'codejercicio', $exercises)
             ->addFilterSelectWhere('status', [
-                ['label' => Tools::lang()->trans('model-390'), 'where' => [new DataBaseWhere('periodo', 'Y')]]
+                ['label' => Tools::lang()->trans('model-390'), 'where' => [Where::eq('periodo', 'Y')]]
             ]);
     }
 }

--- a/Lib/Accounting/VatRegularizationToAccounting.php
+++ b/Lib/Accounting/VatRegularizationToAccounting.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * This file is part of Modelo303 plugin for FacturaScripts
- * Copyright (C) 2019-2024 Carlos Garcia Gomez <carlos@facturascripts.com>
+ * Copyright (C) 2019-2026 Carlos Garcia Gomez <carlos@facturascripts.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -19,8 +19,8 @@
 
 namespace FacturaScripts\Plugins\Modelo303\Lib\Accounting;
 
-use FacturaScripts\Core\Base\DataBase\DataBaseWhere;
 use FacturaScripts\Core\Model\FacturaCliente;
+use FacturaScripts\Core\Where;
 use FacturaScripts\Core\Model\FacturaProveedor;
 use FacturaScripts\Core\Model\RegularizacionImpuesto;
 use FacturaScripts\Core\Tools;
@@ -128,9 +128,9 @@ class VatRegularizationToAccounting
         $accTools = new SubAccountTools();
         $field = 'COALESCE(subcuentas.codcuentaesp, cuentas.codcuentaesp)';
         $where = [
-            new DataBaseWhere('asientos.codejercicio', $reg->codejercicio),
-            new DataBaseWhere('asientos.fecha', $reg->fechainicio, '>='),
-            new DataBaseWhere('asientos.fecha', $reg->fechafin, '<='),
+            Where::eq('asientos.codejercicio', $reg->codejercicio),
+            Where::gte('asientos.fecha', $reg->fechainicio),
+            Where::lte('asientos.fecha', $reg->fechafin),
             $accTools->whereForSpecialAccounts($field, SubAccountTools::SPECIAL_GROUP_TAX_ALL)
         ];
         $orderBy = [
@@ -168,11 +168,11 @@ class VatRegularizationToAccounting
     private function checkInvoicesWithoutAccEntry($reg): bool
     {
         $where = [
-            new DataBaseWhere('codejercicio', $reg->codejercicio),
-            new DataBaseWhere('idempresa', $reg->idempresa),
-            new DataBaseWhere('fecha', $reg->fechainicio, '>='),
-            new DataBaseWhere('fecha', $reg->fechafin, '<='),
-            new DataBaseWhere('idasiento', 'IS NULL')
+            Where::eq('codejercicio', $reg->codejercicio),
+            Where::eq('idempresa', $reg->idempresa),
+            Where::gte('fecha', $reg->fechainicio),
+            Where::lte('fecha', $reg->fechafin),
+            Where::isNull('idasiento'),
         ];
 
         $facturasSinAsiento = FacturaCliente::all($where, [], 0, 1);

--- a/Model/Join/PartidaImpuesto.php
+++ b/Model/Join/PartidaImpuesto.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * This file is part of Modelo303 plugin for FacturaScripts
- * Copyright (C) 2017-2024 Carlos Garcia Gomez <carlos@facturascripts.com>
+ * Copyright (C) 2017-2026 Carlos Garcia Gomez <carlos@facturascripts.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -19,9 +19,9 @@
 
 namespace FacturaScripts\Plugins\Modelo303\Model\Join;
 
-use FacturaScripts\Core\Base\DataBase\DataBaseWhere;
 use FacturaScripts\Core\Model\Base\BusinessDocument;
-use FacturaScripts\Core\Model\Base\JoinModel;
+use FacturaScripts\Core\Template\JoinModel;
+use FacturaScripts\Core\Where;
 use FacturaScripts\Dinamic\Model\FacturaCliente;
 use FacturaScripts\Dinamic\Model\FacturaProveedor;
 
@@ -54,7 +54,7 @@ class PartidaImpuesto extends JoinModel
 
     protected function getFactura(): BusinessDocument
     {
-        $where = [new DataBaseWhere('idasiento', $this->idasiento ?? 0)];
+        $where = [Where::eq('idasiento', $this->idasiento ?? 0)];
 
         $facturaCliente = new FacturaCliente();
         if ($facturaCliente->loadWhere($where)) {

--- a/Model/Join/PartidaImpuestoResumen.php
+++ b/Model/Join/PartidaImpuestoResumen.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * This file is part of Modelo303 plugin for FacturaScripts
- * Copyright (C) 2017-2025 Carlos Garcia Gomez <carlos@facturascripts.com>
+ * Copyright (C) 2017-2026 Carlos Garcia Gomez <carlos@facturascripts.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -18,7 +18,7 @@
  */
 namespace FacturaScripts\Plugins\Modelo303\Model\Join;
 
-use FacturaScripts\Core\Model\Base\JoinModel;
+use FacturaScripts\Core\Template\JoinModel;
 
 /**
  * Auxiliary model to load a resume of accounting entries with VAT
@@ -105,7 +105,7 @@ class PartidaImpuestoResumen extends JoinModel
      *
      * @param array $data
      */
-    protected function loadFromData(array $data)
+    protected function loadFromData(array $data): void
     {
         parent::loadFromData($data);
 

--- a/Test/main/ComprobarFechaDevengoTest.php
+++ b/Test/main/ComprobarFechaDevengoTest.php
@@ -3,8 +3,8 @@
 namespace FacturaScripts\Test\Plugins;
 
 use Exception;
-use FacturaScripts\Core\Base\DataBase\DataBaseWhere;
 use FacturaScripts\Core\Model\FacturaCliente;
+use FacturaScripts\Core\Where;
 use FacturaScripts\Core\Tools;
 use FacturaScripts\Plugins\Modelo303\Model\Join\PartidaImpuestoResumen;
 use FacturaScripts\Test\Traits\RandomDataTrait;
@@ -67,8 +67,8 @@ class ComprobarFechaDevengoTest extends Modelo303TestCase
         // comprobamos que solo obtiene los resultados de la factura de hoy
         $partidaImpuestoResumen = new PartidaImpuestoResumen();
         $partida = $partidaImpuestoResumen->all([
-            new DataBaseWhere('COALESCE(subcuentas.codcuentaesp, cuentas.codcuentaesp)', 'IVAREP'),
-            new DataBaseWhere('fecha', Tools::date()),
+            Where::eq('COALESCE(subcuentas.codcuentaesp, cuentas.codcuentaesp)', 'IVAREP'),
+            Where::eq('fecha', Tools::date()),
         ])[0];
         $this->assertEquals($invoiceFechaHoy->totaliva, $partida->cuotaiva);
         $this->assertEquals($invoiceFechaHoy->totaliva, $partida->haber);
@@ -76,8 +76,8 @@ class ComprobarFechaDevengoTest extends Modelo303TestCase
         // comprobamos que solo obtiene los resultados de la factura de fecha anterior
         $partidaImpuestoResumen = new PartidaImpuestoResumen();
         $partida = $partidaImpuestoResumen->all([
-            new DataBaseWhere('COALESCE(subcuentas.codcuentaesp, cuentas.codcuentaesp)', 'IVAREP'),
-            new DataBaseWhere('fecha', Tools::date('-1 month')),
+            Where::eq('COALESCE(subcuentas.codcuentaesp, cuentas.codcuentaesp)', 'IVAREP'),
+            Where::eq('fecha', Tools::date('-1 month')),
         ])[0];
         $this->assertEquals($invoiceFechaDevengoAnterior->totaliva, $partida->cuotaiva);
         $this->assertEquals($invoiceFechaDevengoAnterior->totaliva, $partida->haber);
@@ -85,8 +85,8 @@ class ComprobarFechaDevengoTest extends Modelo303TestCase
         // comprobamos que solo obtiene los resultados de la factura de fecha posterior
         $partidaImpuestoResumen = new PartidaImpuestoResumen();
         $partida = $partidaImpuestoResumen->all([
-            new DataBaseWhere('COALESCE(subcuentas.codcuentaesp, cuentas.codcuentaesp)', 'IVAREP'),
-            new DataBaseWhere('fecha', Tools::date('+1 month')),
+            Where::eq('COALESCE(subcuentas.codcuentaesp, cuentas.codcuentaesp)', 'IVAREP'),
+            Where::eq('fecha', Tools::date('+1 month')),
         ])[0];
         $this->assertEquals($invoiceFechaDevengoPosterior->totaliva, $partida->cuotaiva);
         $this->assertEquals($invoiceFechaDevengoPosterior->totaliva, $partida->haber);
@@ -96,7 +96,7 @@ class ComprobarFechaDevengoTest extends Modelo303TestCase
 
         $partidaImpuestoResumen = new PartidaImpuestoResumen();
         $partida = $partidaImpuestoResumen->all([
-            new DataBaseWhere('COALESCE(subcuentas.codcuentaesp, cuentas.codcuentaesp)', 'IVAREP'),
+            Where::eq('COALESCE(subcuentas.codcuentaesp, cuentas.codcuentaesp)', 'IVAREP'),
         ])[0];
         $this->assertEquals($totalIVAFacturasCliente, $partida->cuotaiva);
         $this->assertEquals($totalIVAFacturasCliente, $partida->haber);

--- a/facturascripts.ini
+++ b/facturascripts.ini
@@ -1,4 +1,4 @@
 name = 'Modelo303'
 description = 'Modelo 303 y 390 de la Hacienda española para la declaración trimestral y anual de IVA.'
 version = 2.91
-min_version = 2025.6
+min_version = 2026


### PR DESCRIPTION
https://facturascripts.com/roadmap/4709
-Se actualizo todos los JoinModel para heredar de la nueva clase de Core/Template
- Se reemplazaron instancias de DataBaseWhere por la nueva clase Where en varios archivos:
  - ComprobarFechaDevengoTest.php
  - EditRegularizacionImpuesto.php
  - ListRegularizacionImpuesto.php
  - PartidaImpuesto.php
  - PartidaImpuestoResumen.php
  - VatRegularizationToAccounting.php

- Se actualizó la versión mínima requerida en facturascripts.ini a 2026.
- Se corrigió la fecha de copyright en varios archivos a 2026.