### PR TITLE
Añadidas columnas IVA soportado

### DIFF
--- a/Lib/Modelo303.php
+++ b/Lib/Modelo303.php
@@ -87,10 +87,20 @@ class Modelo303
         ],
 
         // Compras en importaciones
-        'IVASIM' => ['21' => ['base' => '32', 'cuota' => '33']],
+        'IVASIM' => [
+            '21' => ['base' => '32', 'cuota' => '33'],
+            '10' => ['base' => '32', 'cuota' => '33'],
+            '4'  => ['base' => '32', 'cuota' => '33'],
+            '0'  => ['base' => '32', 'cuota' => '33'],
+        ],
 
         // Compras en adquisiciones intracomunitarias
-        'IVASUE' => ['21' => ['base' => '36', 'cuota' => '37']],
+        'IVASUE' => [
+            '21' => ['base' => '36', 'cuota' => '37'],
+            '10' => ['base' => '36', 'cuota' => '37'],
+            '4'  => ['base' => '36', 'cuota' => '37'],
+            '0'  => ['base' => '36', 'cuota' => '37'],
+        ],
 
         // Operaciones exentas
         'IVASEX' => ['0'  => ['base' => '60', 'cuota' => null]],

--- a/Translation/es_ES.json
+++ b/Translation/es_ES.json
@@ -4,7 +4,6 @@
     "accounting-entry-not-found": "No se han encontrado asientos para este periodo",
     "base": "Base",
     "deductible-vat": "IVA deducible",
-    "deductible-vat-28": "Por cuotas soportadas en operaciones interiores corrientes",
     "general-regime-result": "Resultado del régimen general",
     "invoices-without-acc-entry": "Existen facturas sin asiento. Debe crear los asientos de todas las facturas.",
     "model-303": "Modelo 303",
@@ -19,5 +18,8 @@
     "total-result-of-the-general-regime": "Resultado total del régimen general",
     "total-to-deduct": "Total a deducir",
     "vat-accrued": "IVA devengado",
-    "year-model-390": "Año (modelo 390)"
+    "year-model-390": "Año (modelo 390)",
+    "deductible-vat-28": "por operaciones interiores corrientes",
+    "deductible-vat-32": "por importaciones",
+    "deductible-vat-36": "por adquisiciones intracomunitarias"
 }

--- a/View/Modelo303.html.twig
+++ b/View/Modelo303.html.twig
@@ -225,7 +225,7 @@
                 </thead>
                 <tbody>
                 <tr>
-                    <td>{{ trans('deductible-vat') }}</td>
+                    <td>{{ trans('deductible-vat-28') }}</td>
                     <td class="text-center">28</td>
                     <td class="text-end">
                         <strong>{{ fsc.modelo303.casillaStr('28') }}</strong>
@@ -233,6 +233,28 @@
                     <td class="text-center">29</td>
                     <td class="text-end">
                         <strong>{{ fsc.modelo303.casillaStr('29') }}</strong>
+                    </td>
+                </tr>
+                <tr>
+                    <td>{{ trans('deductible-vat-32') }}</td>
+                    <td class="text-center">32</td>
+                    <td class="text-end">
+                        <strong>{{ fsc.modelo303.casillaStr('32') }}</strong>
+                    </td>
+                    <td class="text-center">33</td>
+                    <td class="text-end">
+                        <strong>{{ fsc.modelo303.casillaStr('33') }}</strong>
+                    </td>
+                </tr>
+                <tr>
+                    <td>{{ trans('deductible-vat-36') }}</td>
+                    <td class="text-center">36</td>
+                    <td class="text-end">
+                        <strong>{{ fsc.modelo303.casillaStr('36') }}</strong>
+                    </td>
+                    <td class="text-center">37</td>
+                    <td class="text-end">
+                        <strong>{{ fsc.modelo303.casillaStr('37') }}</strong>
                     </td>
                 </tr>
                 </tbody>


### PR DESCRIPTION
Se han añadido las columnas que ya se calculaban para el IVA soportado Intracomunitario (36 y 37) y de Importaciones (32 y 33)

Se han puesto de manera temporal y para pruebas en Español, las traducciones de dichas columnas. Pendiente de subirlas al sistema global de traducciones.