### PR TITLE
Modelo 303: corregir redondeo y mapear todas las operaciones (tarea 4542)

### DIFF
--- a/Controller/EditRegularizacionImpuesto.php
+++ b/Controller/EditRegularizacionImpuesto.php
@@ -94,6 +94,44 @@ class EditRegularizacionImpuesto extends EditController
     }
 
     /**
+     * Builds the common filter used by the summary, purchases/sales and accounting-entry
+     * queries, so the three of them always work over the SAME set of accounting entries.
+     *
+     * @param int $group grupo de cuentas especiales (TAX_ALL, TAX_INPUT, TAX_OUTPUT)
+     * @return array
+     */
+    private function commonTaxWhere(int $group): array
+    {
+        $model = $this->getModel();
+        $excludedOperations = implode(',', [Asiento::OPERATION_OPENING, Asiento::OPERATION_CLOSING]);
+
+        // ids de los asientos de TODAS las regularizaciones (para excluirlos)
+        $regIds = [];
+        foreach (RegularizacionImpuesto::all() as $reg) {
+            if ($reg->idasiento) {
+                $regIds[] = $reg->idasiento;
+            }
+        }
+
+        $subAccountTools = new SubAccountTools();
+        $where = [
+            Where::eq('asientos.idempresa', $model->idempresa),
+            Where::eq('asientos.codejercicio', $model->codejercicio),
+            Where::gte('asientos.fecha', $model->fechainicio),
+            Where::lte('asientos.fecha', $model->fechafin),
+            Where::eq('COALESCE(series.siniva, false)', false),
+            Where::notIn("COALESCE(asientos.operacion, '')", $excludedOperations),
+            $subAccountTools->whereForSpecialAccounts('COALESCE(subcuentas.codcuentaesp, cuentas.codcuentaesp)', $group),
+        ];
+
+        if (false === empty($regIds)) {
+            $where[] = Where::notIn('asientos.idasiento', implode(',', $regIds));
+        }
+
+        return $where;
+    }
+
+    /**
      * Create accounting entry action procedure.
      *
      * @return void
@@ -200,6 +238,22 @@ class EditRegularizacionImpuesto extends EditController
     }
 
     /**
+     * Setup actions for view.
+     *
+     * @param string $viewName
+     * @param bool $clickable
+     * @return void
+     */
+    private function disableButtons(string $viewName, bool $clickable = false): void
+    {
+        $this->setSettings($viewName, 'btnDelete', false)
+            ->setSettings('btnNew', false)
+            ->setSettings('checkBoxes', false)
+            ->setSettings('clickable', $clickable)
+            ->setSettings('btnPrint', true);
+    }
+
+    /**
      * Run the actions that alter data before reading it.
      *
      * @param string $action
@@ -271,78 +325,6 @@ class EditRegularizacionImpuesto extends EditController
     }
 
     /**
-     * Load data view procedure
-     *
-     * @param string $viewName
-     * @param BaseView $view
-     * @throws Exception
-     */
-    protected function loadData($viewName, $view): void
-    {
-        switch ($viewName) {
-            case 'EditRegularizacionImpuesto':
-                parent::loadData($viewName, $view);
-                $this->settingsMainView();
-                break;
-
-            case 'ListPartidaImpuestoResumen':
-                $mainModel = $this->getModel();
-                $excludedOperations = implode(',', [Asiento::OPERATION_OPENING, Asiento::OPERATION_CLOSING]);
-                $where = [
-                    Where::sub([
-                        Where::like('partidas.codsubcuenta', '477%'),
-                        Where::orLike('partidas.codsubcuenta', '472%'),
-                    ]),
-                    Where::eq('asientos.idempresa', $mainModel->idempresa),
-                    Where::gte('asientos.fecha', $mainModel->fechainicio),
-                    Where::lte('asientos.fecha', $mainModel->fechafin),
-                    Where::eq('COALESCE(series.siniva, false)', false),
-                    Where::notIn("COALESCE(asientos.operacion, '')", $excludedOperations),
-                ];
-
-                if (false === empty($mainModel->idasiento)) {
-                    $where[] = Where::notEq('partidas.idasiento', $mainModel->idasiento);
-                }
-                $view->loadData(false, $where, [
-                    'COALESCE(subcuentas.codcuentaesp, cuentas.codcuentaesp)' => 'ASC',
-                    'partidas.codsubcuenta' => 'ASC',
-                ]);
-
-                $this->modelo303->loadFromResumen($view->cursor); // Load data into Modelo303 View
-                $this->checkInvoicesWithoutAccounting($mainModel);
-                break;
-
-            case 'ListPartida':
-                $this->getListPartida($view);
-                break;
-
-            case 'ListPartidaImpuesto-1':
-                $this->getListPartidaImpuesto($view, SubAccountTools::SPECIAL_GROUP_TAX_INPUT);
-                break;
-
-            case 'ListPartidaImpuesto-2':
-                $this->getListPartidaImpuesto($view, SubAccountTools::SPECIAL_GROUP_TAX_OUTPUT);
-                break;
-        }
-    }
-
-    /**
-     * Setup actions for view.
-     *
-     * @param string $viewName
-     * @param bool $clickable
-     * @return void
-     */
-    private function disableButtons(string $viewName, bool $clickable = false): void
-    {
-        $this->setSettings($viewName, 'btnDelete', false)
-            ->setSettings('btnNew', false)
-            ->setSettings('checkBoxes', false)
-            ->setSettings('clickable', $clickable)
-            ->setSettings('btnPrint', true);
-    }
-
-    /**
      * Load data for accounting entry.
      *
      * @param BaseView $view
@@ -383,27 +365,65 @@ class EditRegularizacionImpuesto extends EditController
      */
     private function getPartidaImpuestoWhere(int $group): array
     {
-        // obtenemos todos los ids de los asientos de las regularizaciones
-        $ids = [];
-        foreach (RegularizacionImpuesto::all() as $reg) {
-            if ($reg->idasiento) {
-                $ids[] = $reg->idasiento;
-            }
-        }
+        return $this->commonTaxWhere($group);
+    }
 
-        $subAccountTools = new SubAccountTools();
-        return [
-            Where::notIn('asientos.idasiento', implode(',', $ids)),
-            Where::eq('asientos.codejercicio', $this->getModel()->codejercicio),
-            Where::gte('asientos.fecha', $this->getModel()->fechainicio),
-            Where::lte('asientos.fecha', $this->getModel()->fechafin),
-            Where::eq('COALESCE(series.siniva, 0)', 0),
-            Where::sub([
-                Where::notEq('partidas.baseimponible', 0),
-                Where::orGt('COALESCE(partidas.iva, 0)', 0),
-            ]),
-            $subAccountTools->whereForSpecialAccounts('COALESCE(subcuentas.codcuentaesp, cuentas.codcuentaesp)', $group)
-        ];
+    /**
+     * Load data view procedure
+     *
+     * @param string $viewName
+     * @param BaseView $view
+     * @throws Exception
+     */
+    protected function loadData($viewName, $view): void
+    {
+        switch ($viewName) {
+            case 'EditRegularizacionImpuesto':
+                parent::loadData($viewName, $view);
+                $this->settingsMainView();
+                break;
+
+            case 'ListPartidaImpuestoResumen':
+                $mainModel = $this->getModel();
+
+                // mismo criterio que las pestañas Compras/Ventas y que el asiento de regularización
+                $where = $this->commonTaxWhere(SubAccountTools::SPECIAL_GROUP_TAX_ALL);
+                $view->loadData(false, $where, [
+                    'COALESCE(subcuentas.codcuentaesp, cuentas.codcuentaesp)' => 'ASC',
+                    'partidas.codsubcuenta' => 'ASC',
+                ]);
+
+                // cargamos el resumen de IVA (casillas del régimen general)
+                $this->modelo303->loadFromResumen($view->cursor);
+
+                // cargamos las bases exentas/informativas de ventas (casillas 59, 60 y 122)
+                $this->modelo303->loadFromSalesInvoices(
+                    (int)$mainModel->idempresa,
+                    (string)$mainModel->codejercicio,
+                    (string)$mainModel->fechainicio,
+                    (string)$mainModel->fechafin
+                );
+
+                // mostramos los avisos de importes que no encajan en ninguna casilla
+                foreach ($this->modelo303->getAvisos() as $aviso) {
+                    Tools::log()->warning($aviso);
+                }
+
+                $this->checkInvoicesWithoutAccounting($mainModel);
+                break;
+
+            case 'ListPartida':
+                $this->getListPartida($view);
+                break;
+
+            case 'ListPartidaImpuesto-1':
+                $this->getListPartidaImpuesto($view, SubAccountTools::SPECIAL_GROUP_TAX_INPUT);
+                break;
+
+            case 'ListPartidaImpuesto-2':
+                $this->getListPartidaImpuesto($view, SubAccountTools::SPECIAL_GROUP_TAX_OUTPUT);
+                break;
+        }
     }
 
     /**

--- a/Lib/Accounting/VatRegularizationToAccounting.php
+++ b/Lib/Accounting/VatRegularizationToAccounting.php
@@ -123,43 +123,6 @@ class VatRegularizationToAccounting
         return true;
     }
 
-    protected function getSubtotals(RegularizacionImpuesto $reg): array
-    {
-        $accTools = new SubAccountTools();
-        $field = 'COALESCE(subcuentas.codcuentaesp, cuentas.codcuentaesp)';
-        $excludedOperations = implode(',', [Asiento::OPERATION_OPENING, Asiento::OPERATION_CLOSING]);
-        $where = [
-            Where::eq('asientos.codejercicio', $reg->codejercicio),
-            Where::gte('asientos.fecha', $reg->fechainicio),
-            Where::lte('asientos.fecha', $reg->fechafin),
-            Where::notIn("COALESCE(asientos.operacion, '')", $excludedOperations),
-            $accTools->whereForSpecialAccounts($field, SubAccountTools::SPECIAL_GROUP_TAX_ALL)
-        ];
-        $orderBy = [
-            $field => 'ASC',
-            'partidas.iva' => 'ASC',
-            'partidas.recargo' => 'ASC'
-        ];
-
-        $subtotals = [];
-        $inputTaxGroup = $accTools->specialAccountsForGroup(SubAccountTools::SPECIAL_GROUP_TAX_INPUT);
-        $outputTaxGroup = $accTools->specialAccountsForGroup(SubAccountTools::SPECIAL_GROUP_TAX_OUTPUT);
-        $totals = new PartidaImpuestoResumen();
-        foreach ($totals->all($where, $orderBy) as $row) {
-            if (!isset($subtotals[$row->idsubcuenta])) {
-                $subtotals[$row->idsubcuenta] = ['debe' => 0.0, 'haber' => 0.0];
-            }
-
-            if (in_array($row->codcuentaesp, $outputTaxGroup)) {
-                $subtotals[$row->idsubcuenta]['debe'] += $row->cuotaiva + $row->cuotarecargo;
-            } elseif (in_array($row->codcuentaesp, $inputTaxGroup)) {
-                $subtotals[$row->idsubcuenta]['haber'] += $row->cuotaiva + $row->cuotarecargo;
-            }
-        }
-
-        return $subtotals;
-    }
-
     /**
      * Comprueba si hay facturas sin asiento contable
      *
@@ -184,5 +147,57 @@ class VatRegularizationToAccounting
 
         $facturasSinAsiento = FacturaProveedor::all($where, [], 0, 1);
         return empty($facturasSinAsiento);
+    }
+
+    protected function getSubtotals(RegularizacionImpuesto $reg): array
+    {
+        $accTools = new SubAccountTools();
+        $field = 'COALESCE(subcuentas.codcuentaesp, cuentas.codcuentaesp)';
+        $excludedOperations = implode(',', [Asiento::OPERATION_OPENING, Asiento::OPERATION_CLOSING]);
+
+        // mismo criterio que las pestañas Resumen/Compras/Ventas para que el asiento cuadre con ellas
+        $regIds = [];
+        foreach (RegularizacionImpuesto::all() as $other) {
+            if ($other->idasiento) {
+                $regIds[] = $other->idasiento;
+            }
+        }
+
+        $where = [
+            Where::eq('asientos.idempresa', $reg->idempresa),
+            Where::eq('asientos.codejercicio', $reg->codejercicio),
+            Where::gte('asientos.fecha', $reg->fechainicio),
+            Where::lte('asientos.fecha', $reg->fechafin),
+            Where::eq('COALESCE(series.siniva, false)', false),
+            Where::notIn("COALESCE(asientos.operacion, '')", $excludedOperations),
+            $accTools->whereForSpecialAccounts($field, SubAccountTools::SPECIAL_GROUP_TAX_ALL)
+        ];
+
+        if (false === empty($regIds)) {
+            $where[] = Where::notIn('asientos.idasiento', implode(',', $regIds));
+        }
+        $orderBy = [
+            $field => 'ASC',
+            'partidas.iva' => 'ASC',
+            'partidas.recargo' => 'ASC'
+        ];
+
+        $subtotals = [];
+        $inputTaxGroup = $accTools->specialAccountsForGroup(SubAccountTools::SPECIAL_GROUP_TAX_INPUT);
+        $outputTaxGroup = $accTools->specialAccountsForGroup(SubAccountTools::SPECIAL_GROUP_TAX_OUTPUT);
+        $totals = new PartidaImpuestoResumen();
+        foreach ($totals->all($where, $orderBy) as $row) {
+            if (!isset($subtotals[$row->idsubcuenta])) {
+                $subtotals[$row->idsubcuenta] = ['debe' => 0.0, 'haber' => 0.0];
+            }
+
+            if (in_array($row->codcuentaesp, $outputTaxGroup)) {
+                $subtotals[$row->idsubcuenta]['debe'] += $row->cuotaiva + $row->cuotarecargo;
+            } elseif (in_array($row->codcuentaesp, $inputTaxGroup)) {
+                $subtotals[$row->idsubcuenta]['haber'] += $row->cuotaiva + $row->cuotarecargo;
+            }
+        }
+
+        return $subtotals;
     }
 }

--- a/Lib/Modelo303.php
+++ b/Lib/Modelo303.php
@@ -21,7 +21,10 @@ namespace FacturaScripts\Plugins\Modelo303\Lib;
 
 use FacturaScripts\Core\Base\DataBase;
 use FacturaScripts\Core\Tools;
+use FacturaScripts\Core\Where;
+use FacturaScripts\Dinamic\Lib\InvoiceOperation;
 use FacturaScripts\Dinamic\Model\Ejercicio;
+use FacturaScripts\Dinamic\Model\FacturaCliente;
 use FacturaScripts\Dinamic\Model\Join\PartidaImpuestoResumen;
 
 /**
@@ -34,11 +37,11 @@ class Modelo303
     private const MAX_SQUARE = 200;
 
     /**
-     * Stores all model squares.
-     * Each key is the AEAT square number.
-     *   '01' => 0.00, '02' => 0.00, ...
+     * Warnings collected while loading data (amounts not assigned to any square).
+     *
+     * @var string[]
      */
-    private array $square;
+    private array $avisos = [];
 
     /**
      * Structure for know to assign values to squares.
@@ -58,11 +61,10 @@ class Modelo303
             '21'  => ['base' => '07', 'cuota' => '09'],
         ],
 
-        // Adquisiciones intracomunitarias
-        'IVARUE' => ['21' => ['base' => '10', 'cuota' => '11']],
-
-        // Operaciones con inversión del sujeto pasivo
-        // TODO: 'xxxxx' =>  ['21' => ['base' => '12', 'cuota' => '13']],
+        // Adquisiciones intracomunitarias (cualquier tipo va a 10/11)
+        'IVARUE' => [
+            '*' => ['base' => '10', 'cuota' => '11'],
+        ],
 
         // Recargo de equivalencia
         'IVARRE' => [
@@ -74,37 +76,37 @@ class Modelo303
         ],
 
         // Operaciones exentas
-        'IVAREX' => ['0' => ['base' => '150', 'cuota' => null]],
+        'IVAREX' => ['*' => ['base' => '150', 'cuota' => null]],
 
         /*
          * IVA soportado (deducible)
          * Compras nacionales (régimen general)
          */
         'IVASOP' => [
-            '21' => ['base' => '28', 'cuota' => '29'],
-            '10' => ['base' => '28', 'cuota' => '29'],
-            '4'  => ['base' => '28', 'cuota' => '29'],
+            '*' => ['base' => '28', 'cuota' => '29'],
         ],
 
-        // Compras en importaciones
+        // Compras en importaciones (cualquier tipo va a 32/33)
         'IVASIM' => [
-            '21' => ['base' => '32', 'cuota' => '33'],
-            '10' => ['base' => '32', 'cuota' => '33'],
-            '4'  => ['base' => '32', 'cuota' => '33'],
-            '0'  => ['base' => '32', 'cuota' => '33'],
+            '*' => ['base' => '32', 'cuota' => '33'],
         ],
 
-        // Compras en adquisiciones intracomunitarias
+        // Compras en adquisiciones intracomunitarias (cualquier tipo va a 36/37)
         'IVASUE' => [
-            '21' => ['base' => '36', 'cuota' => '37'],
-            '10' => ['base' => '36', 'cuota' => '37'],
-            '4'  => ['base' => '36', 'cuota' => '37'],
-            '0'  => ['base' => '36', 'cuota' => '37'],
+            '*' => ['base' => '36', 'cuota' => '37'],
         ],
 
-        // Operaciones exentas
-        'IVASEX' => ['0'  => ['base' => '60', 'cuota' => null]],
+        // Operaciones exentas: las compras exentas no se deducen ni figuran en el
+        // resultado del régimen general; se reconocen para no generar avisos.
+        'IVASEX' => ['*' => ['base' => null, 'cuota' => null]],
     ];
+
+    /**
+     * Stores all model squares.
+     * Each key is the AEAT square number.
+     *   '01' => 0.00, '02' => 0.00, ...
+     */
+    private array $square;
 
     /**
      * Initializes the tax rates for each square.
@@ -155,6 +157,17 @@ class Modelo303
     }
 
     /**
+     * Returns the list of warnings collected while loading data
+     * (amounts that could not be assigned to any square).
+     *
+     * @return string[]
+     */
+    public function getAvisos(): array
+    {
+        return $this->avisos;
+    }
+
+    /**
      * Loads summary data from an array of PartidaImpuestoResumen.
      *
      * @param PartidaImpuestoResumen[] $resumen
@@ -164,6 +177,8 @@ class Modelo303
         foreach ($resumen as $item) {
             $this->addMovimiento(
                 $item->codcuentaesp ?? '',
+                $item->operacion ?? '',
+                $item->tipodoc ?? '',
                 (float) $item->iva,
                 (float) $item->recargo,
                 (float) $item->baseimponible,
@@ -171,6 +186,35 @@ class Modelo303
             );
         }
         $this->calculateTotals();
+    }
+
+    /**
+     * Loads the exempt/informative tax bases of sales invoices (without VAT entries)
+     * into their squares: intracommunity (59), exports (60) and reverse charge (122).
+     *
+     * @param int $idempresa
+     * @param string $codejercicio
+     * @param string $dateStart
+     * @param string $dateEnd
+     */
+    public function loadFromSalesInvoices(int $idempresa, string $codejercicio, string $dateStart, string $dateEnd): void
+    {
+        $where = [
+            Where::eq('idempresa', $idempresa),
+            Where::eq('codejercicio', $codejercicio),
+            Where::gte('fecha', $dateStart),
+            Where::lte('fecha', $dateEnd),
+            Where::in('operacion', [
+                InvoiceOperation::INTRA_COMMUNITY,
+                InvoiceOperation::INTRA_COMMUNITY_SERVICES,
+                InvoiceOperation::EXPORT,
+                InvoiceOperation::REVERSE_CHARGE,
+            ]),
+        ];
+
+        foreach (FacturaCliente::all($where, [], 0, 0) as $invoice) {
+            $this->addBaseExentaVenta((string)$invoice->operacion, (float)$invoice->neto);
+        }
     }
 
     public static function treasury(string $codejercicio, string $period): array
@@ -193,20 +237,75 @@ class Modelo303
     }
 
     /**
-     * Add a tax movement to the model (base + quota by type and rate)
-     * - Determine the correct square based on the type and tax rate.
-     * - Update the base and quota squares accordingly.
+     * Adds the exempt tax base of a sales invoice to its informative square.
      *
-     * @param string $tipo
+     * @param string $operacion
+     * @param float $base
+     * @return void
+     */
+    private function addBaseExentaVenta(string $operacion, float $base): void
+    {
+        switch ($operacion) {
+            case InvoiceOperation::EXPORT:
+                $this->square['60'] += $base;
+                break;
+
+            case InvoiceOperation::INTRA_COMMUNITY:
+            case InvoiceOperation::INTRA_COMMUNITY_SERVICES:
+                $this->square['59'] += $base;
+                break;
+
+            case InvoiceOperation::REVERSE_CHARGE:
+                $this->square['122'] += $base;
+                break;
+        }
+    }
+
+    /**
+     * Adds a base and/or quota amount to the given squares.
+     *
+     * @param string|null $baseSquare
+     * @param string|null $cuotaSquare
+     * @param float $base
+     * @param float $cuota
+     * @return void
+     */
+    private function addCasilla(?string $baseSquare, ?string $cuotaSquare, float $base, float $cuota): void
+    {
+        if (false === empty($baseSquare)) {
+            $this->square[$baseSquare] += $base;
+        }
+
+        if (false === empty($cuotaSquare)) {
+            $this->square[$cuotaSquare] += $cuota;
+        }
+    }
+
+    /**
+     * Add a tax movement to the model (base + quota by type and rate)
+     * - Special operations (reverse charge, intracommunity, import) are routed by
+     *   the invoice operation type to their specific squares.
+     * - The rest follows the casillaMap by special account and tax rate.
+     *
+     * @param string $tipo cuenta especial de IVA (IVAREP, IVASOP, IVARUE, ...)
+     * @param string $operacion tipo de operación de la factura (intracomunitaria, inv-sujeto-pasivo, ...)
+     * @param string $tipodoc 'compra' o 'venta'
      * @param float $iva
      * @param float $recargo
      * @param float $base
      * @param float $cuota
      * @return void
      */
-    private function addMovimiento(string $tipo, float $iva, float $recargo, float $base, float $cuota): void
+    private function addMovimiento(string $tipo, string $operacion, string $tipodoc, float $iva, float $recargo, float $base, float $cuota): void
     {
+        // Las operaciones especiales (ISP, intracomunitarias, importación) deciden la casilla
+        // por el tipo de operación de la factura, no solo por la cuenta especial.
+        if ($this->addMovimientoEspecial($tipo, $operacion, $tipodoc, $base, $cuota)) {
+            return;
+        }
+
         if (false === isset($this->casillaMap[$tipo])) {
+            $this->registrarNoMapeado($tipo, $operacion, $base, $cuota);
             return;
         }
 
@@ -219,20 +318,77 @@ class Modelo303
             ?? null;
 
         if ($grupo === null) {
+            $this->registrarNoMapeado($tipo, $operacion, $base, $cuota, $tax);
             return;
         }
 
-        // Update base and quota squares.
-        if (false === empty($grupo['base'])) {
-            $this->square[$grupo['base']] += $base;
+        // For recargo, if cuota is zero, calculate it from base and recargo rate
+        if ($tipo === 'IVARRE' && $cuota == 0.0 && $recargo > 0.0) {
+            $cuota = $base * ($recargo / 100.0);
         }
 
-        if (false === empty($grupo['cuota'])) {
-            // For recargo, if cuota is zero, calculate it from base and recargo rate
-            if ($tipo === 'IVARRE' && $cuota == 0.0 && $recargo > 0.0) {
-                $cuota = $base * ($recargo / 100.0);
-            }
-            $this->square[$grupo['cuota']] += $cuota;
+        $this->addCasilla($grupo['base'] ?? null, $grupo['cuota'] ?? null, $base, $cuota);
+    }
+
+    /**
+     * Routes movements of special invoice operations (reverse charge, intracommunity, import)
+     * to their specific squares. Returns true if the movement has been handled (or intentionally
+     * skipped) and must not follow the standard mapping.
+     *
+     * @param string $tipo
+     * @param string $operacion
+     * @param string $tipodoc
+     * @param float $base
+     * @param float $cuota
+     * @return bool
+     */
+    private function addMovimientoEspecial(string $tipo, string $operacion, string $tipodoc, float $base, float $cuota): bool
+    {
+        $esDevengado = in_array($tipo, ['IVAREP', 'IVARUE', 'IVAREX'], true);
+        $esDeducible = in_array($tipo, ['IVASOP', 'IVASUE', 'IVASIM', 'IVASEX'], true);
+
+        // El recargo de equivalencia y cuentas no fiscales siguen el tratamiento estándar.
+        if (false === $esDevengado && false === $esDeducible) {
+            return false;
+        }
+
+        switch ($operacion) {
+            case InvoiceOperation::REVERSE_CHARGE:
+                // Inversión del sujeto pasivo en COMPRAS: autorrepercusión.
+                // Devengado → 12/13, deducible → 28/29 (el IVA se compensa).
+                if ($tipodoc === 'compra') {
+                    $esDevengado
+                        ? $this->addCasilla('12', '13', $base, $cuota)
+                        : $this->addCasilla('28', '29', $base, $cuota);
+                }
+                // En ventas con ISP el vendedor no repercute IVA; la base informativa (122)
+                // se carga desde las facturas en loadFromSalesInvoices().
+                return true;
+
+            case InvoiceOperation::INTRA_COMMUNITY:
+            case InvoiceOperation::INTRA_COMMUNITY_SERVICES:
+                // Adquisición intracomunitaria (COMPRA): devengado → 10/11, deducible → 36/37.
+                if ($tipodoc === 'compra') {
+                    $esDevengado
+                        ? $this->addCasilla('10', '11', $base, $cuota)
+                        : $this->addCasilla('36', '37', $base, $cuota);
+                }
+                // Entrega intracomunitaria (VENTA): exenta. Las partidas de autorrepercusión
+                // (IVARUE/IVASUE) se compensan y no forman parte del régimen general; la base
+                // informativa (casilla 59) se carga desde las facturas.
+                return true;
+
+            case InvoiceOperation::IMPORT:
+                // Importación (COMPRA): el IVA lo liquida la aduana (DUA). Solo el soportado deducible.
+                if ($esDeducible) {
+                    $this->addCasilla('32', '33', $base, $cuota);
+                }
+                // El IVA devengado de importación (casilla 77 / IVA diferido) no tiene origen
+                // contable automático en FacturaScripts.
+                return true;
+
+            default:
+                return false;
         }
     }
 
@@ -271,23 +427,31 @@ class Modelo303
         $this->square['46'] = $this->square['27'] - $this->square['45'];
     }
 
-    protected static function treasurySaldoCuenta(string $cuenta, string $desde, string $hasta, DataBase $dataBase): float
+    /**
+     * Records a warning for an amount that could not be assigned to any square,
+     * so the user can understand why the summary may not match the purchases/sales tabs.
+     *
+     * @param string $tipo
+     * @param string $operacion
+     * @param float $base
+     * @param float $cuota
+     * @param float|null $tax
+     * @return void
+     */
+    private function registrarNoMapeado(string $tipo, string $operacion, float $base, float $cuota, ?float $tax = null): void
     {
-        $saldo = 0.0;
-
-        if ($dataBase->tableExists('partidas')) {
-            // calculamos el saldo de todos aquellos asientos que afecten a caja
-            $sql = "select sum(debe-haber) as total from partidas where codsubcuenta LIKE " . $dataBase->var2str($cuenta)
-                . " and idasiento in (select idasiento from asientos where fecha >= " . $dataBase->var2str($desde)
-                . " and fecha <= " . $dataBase->var2str($hasta) . ");";
-
-            $data = $dataBase->select($sql);
-            if ($data && $data[0]['total'] !== null) {
-                $saldo = floatval($data[0]['total']);
-            }
+        // No avisamos si no hay importe relevante.
+        if (empty($base) && empty($cuota)) {
+            return;
         }
 
-        return $saldo;
+        $this->avisos[] = Tools::lang()->trans('model303-amount-without-square', [
+            '%type%' => $tipo,
+            '%rate%' => $tax === null ? '-' : Tools::number($tax, 2),
+            '%operation%' => $operacion === '' ? '-' : $operacion,
+            '%base%' => Tools::number($base, 2),
+            '%quota%' => Tools::number($cuota, 2),
+        ]);
     }
 
     protected static function treasuryDates(Ejercicio $exercise, string $period): array
@@ -319,5 +483,24 @@ class Modelo303
                 date('31-12-Y', strtotime($exercise->fechainicio))
             ],
         };
+    }
+
+    protected static function treasurySaldoCuenta(string $cuenta, string $desde, string $hasta, DataBase $dataBase): float
+    {
+        $saldo = 0.0;
+
+        if ($dataBase->tableExists('partidas')) {
+            // calculamos el saldo de todos aquellos asientos que afecten a caja
+            $sql = "select sum(debe-haber) as total from partidas where codsubcuenta LIKE " . $dataBase->var2str($cuenta)
+                . " and idasiento in (select idasiento from asientos where fecha >= " . $dataBase->var2str($desde)
+                . " and fecha <= " . $dataBase->var2str($hasta) . ");";
+
+            $data = $dataBase->select($sql);
+            if ($data && $data[0]['total'] !== null) {
+                $saldo = floatval($data[0]['total']);
+            }
+        }
+
+        return $saldo;
     }
 }

--- a/Model/Join/PartidaImpuesto.php
+++ b/Model/Join/PartidaImpuesto.php
@@ -127,19 +127,23 @@ class PartidaImpuesto extends JoinModel
     {
         parent::loadFromData($data);
 
-        if ($this->iva > 0 && $this->recargo > 0) {
-            $this->cuotaiva = $this->baseimponible * ($this->iva / 100.0);
-            $this->cuotarecargo = $this->baseimponible * ($this->recargo / 100.0);
-        } elseif ($this->iva > 0) {
-            $this->cuotaiva = $this->codcuentaesp === 'IVAREP'
-                ? $data['haber'] - $data['debe']
-                : $data['debe'] - $data['haber'];
-            $this->cuotarecargo = 0.0;
-        } else {
-            $this->cuotarecargo = $this->codcuentaesp === 'IVAREP'
-                ? $data['haber'] - $data['debe']
-                : $data['debe'] - $data['haber'];
+        // La cuota es SIEMPRE el importe realmente contabilizado (debe/haber), nunca un
+        // recálculo base*tipo (que introduce desfases de céntimos). Usamos la misma fórmula
+        // que PartidaImpuestoResumen: debe+haber da el importe en positivo (una de las dos
+        // columnas siempre es 0) y solo invertimos el signo en bases negativas (rectificativas).
+        $debe = (float)($data['debe'] ?? 0.0);
+        $haber = (float)($data['haber'] ?? 0.0);
+        $cuota = ($this->baseimponible < 0 && ($debe + $haber) > 0)
+            ? ($debe + $haber) * -1
+            : $debe + $haber;
+
+        // El destino (IVA o recargo) lo determina la cuenta especial, igual que en el resumen.
+        if ($this->codcuentaesp === 'IVARRE') {
+            $this->cuotarecargo = $cuota;
             $this->cuotaiva = 0.0;
+        } else {
+            $this->cuotaiva = $cuota;
+            $this->cuotarecargo = 0.0;
         }
 
         // si el campo factura está vacío, buscamos la factura con este asiento

--- a/Model/Join/PartidaImpuestoResumen.php
+++ b/Model/Join/PartidaImpuestoResumen.php
@@ -45,6 +45,15 @@ class PartidaImpuestoResumen extends JoinModel
             'codcuentaesp' => 'COALESCE(subcuentas.codcuentaesp, cuentas.codcuentaesp)',
             'tipo_desc' => 'cuentasesp.descripcion',
 
+            // operación de la factura (compra o venta) que originó el asiento,
+            // necesaria para decidir las casillas del 303 en operaciones especiales
+            // (intracomunitaria, inversión del sujeto pasivo, importación, etc.)
+            'operacion' => "COALESCE(facturasprov.operacion, facturascli.operacion, '')",
+
+            // tipo de documento: una compra y una venta intracomunitarias generan las mismas
+            // partidas de IVA (IVARUE/IVASUE), pero van a casillas distintas del 303.
+            'tipodoc' => $this->sqlForTipoDoc(),
+
             'baseimponible' => $this->sqlForRoundedSum('partidas.baseimponible'),
             'debe' => $this->sqlForRoundedSum('partidas.debe'),
             'haber' => $this->sqlForRoundedSum('partidas.haber'),
@@ -65,7 +74,9 @@ class PartidaImpuestoResumen extends JoinModel
             . ', partidas.recargo'
             . ', subcuentas.descripcion'
             . ', COALESCE(subcuentas.codcuentaesp, cuentas.codcuentaesp)'
-            . ', cuentasesp.descripcion';
+            . ', cuentasesp.descripcion'
+            . ", COALESCE(facturasprov.operacion, facturascli.operacion, '')"
+            . ', ' . $this->sqlForTipoDoc();
     }
 
     /**
@@ -80,7 +91,12 @@ class PartidaImpuestoResumen extends JoinModel
             . ' INNER JOIN subcuentas on subcuentas.idsubcuenta = partidas.idsubcuenta'
             . ' INNER JOIN cuentas on cuentas.idcuenta = subcuentas.idcuenta'
             . ' LEFT JOIN cuentasesp on cuentasesp.codcuentaesp = coalesce(subcuentas.codcuentaesp, cuentas.codcuentaesp)'
-            . ' LEFT JOIN series on series.codserie = partidas.codserie';
+            . ' LEFT JOIN series on series.codserie = partidas.codserie'
+            // enlazamos la factura por el asiento contable para conocer el tipo de operación.
+            // Usamos subconsultas que solo exponen idasiento y operacion para no introducir
+            // columnas duplicadas (p.ej. "fecha") que harían ambiguos otros filtros.
+            . ' LEFT JOIN (SELECT idasiento, operacion FROM facturasprov) facturasprov on facturasprov.idasiento = asientos.idasiento'
+            . ' LEFT JOIN (SELECT idasiento, operacion FROM facturascli) facturascli on facturascli.idasiento = asientos.idasiento';
     }
 
     /**
@@ -97,6 +113,8 @@ class PartidaImpuestoResumen extends JoinModel
             'cuentas',
             'cuentasesp',
             'series',
+            'facturasprov',
+            'facturascli',
         ];
     }
 
@@ -136,5 +154,17 @@ class PartidaImpuestoResumen extends JoinModel
     private function sqlForRoundedSum(string $field): string
     {
         return 'ROUND(CAST(SUM(' . $field . ') AS DECIMAL(20, 6)), 2)';
+    }
+
+    /**
+     * SQL snippet to know if the entry comes from a purchase or a sale invoice.
+     *
+     * @return string
+     */
+    private function sqlForTipoDoc(): string
+    {
+        return "CASE WHEN facturasprov.idasiento IS NOT NULL THEN 'compra'
+                     WHEN facturascli.idasiento IS NOT NULL THEN 'venta'
+                     ELSE '' END";
     }
 }

--- a/Test/main/Modelo303SquaresTest.php
+++ b/Test/main/Modelo303SquaresTest.php
@@ -1,0 +1,202 @@
+<?php
+/**
+ * This file is part of Modelo303 plugin for FacturaScripts
+ * Copyright (C) 2026 Carlos Garcia Gomez <carlos@facturascripts.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace FacturaScripts\Test\Plugins;
+
+use FacturaScripts\Dinamic\Lib\InvoiceOperation;
+use FacturaScripts\Plugins\Modelo303\Lib\Modelo303;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Pruebas unitarias del reparto de importes a casillas del modelo 303.
+ * No necesita base de datos: alimenta Modelo303 con filas simuladas del resumen.
+ */
+final class Modelo303SquaresTest extends TestCase
+{
+    public function testCompraImportacion(): void
+    {
+        $modelo = new Modelo303();
+        $modelo->loadFromResumen([
+            $this->row('IVASIM', 21, 5000.0, 1050.0, InvoiceOperation::IMPORT, 'compra'),
+        ]);
+
+        $this->assertEqualsWithDelta(5000.0, $modelo->casilla('32'), 0.001);
+        $this->assertEqualsWithDelta(1050.0, $modelo->casilla('33'), 0.001);
+    }
+
+    public function testCompraIntracomunitaria(): void
+    {
+        $modelo = new Modelo303();
+        // intracomunitaria con cuentas específicas IVARUE/IVASUE
+        $modelo->loadFromResumen([
+            $this->row('IVARUE', 21, 4000.0, 840.0, InvoiceOperation::INTRA_COMMUNITY, 'compra'),
+            $this->row('IVASUE', 21, 4000.0, 840.0, InvoiceOperation::INTRA_COMMUNITY, 'compra'),
+        ]);
+
+        // devengado -> 10/11
+        $this->assertEqualsWithDelta(4000.0, $modelo->casilla('10'), 0.001);
+        $this->assertEqualsWithDelta(840.0, $modelo->casilla('11'), 0.001);
+        // deducible -> 36/37
+        $this->assertEqualsWithDelta(4000.0, $modelo->casilla('36'), 0.001);
+        $this->assertEqualsWithDelta(840.0, $modelo->casilla('37'), 0.001);
+        $this->assertEqualsWithDelta(0.0, $modelo->casilla('46'), 0.001);
+    }
+
+    public function testCompraIntracomunitariaConCuentasGenericas(): void
+    {
+        $modelo = new Modelo303();
+        // intracomunitaria pero contabilizada en IVAREP/IVASOP genéricos:
+        // el tipo de operación debe forzar igualmente 10/11 y 36/37
+        $modelo->loadFromResumen([
+            $this->row('IVAREP', 21, 1000.0, 210.0, InvoiceOperation::INTRA_COMMUNITY_SERVICES, 'compra'),
+            $this->row('IVASOP', 21, 1000.0, 210.0, InvoiceOperation::INTRA_COMMUNITY_SERVICES, 'compra'),
+        ]);
+
+        $this->assertEqualsWithDelta(1000.0, $modelo->casilla('10'), 0.001);
+        $this->assertEqualsWithDelta(210.0, $modelo->casilla('11'), 0.001);
+        $this->assertEqualsWithDelta(1000.0, $modelo->casilla('36'), 0.001);
+        $this->assertEqualsWithDelta(210.0, $modelo->casilla('37'), 0.001);
+        // no debe ir a las casillas nacionales (07/09) ni a las de ISP (12/13)
+        $this->assertEqualsWithDelta(0.0, $modelo->casilla('09'), 0.001);
+        $this->assertEqualsWithDelta(0.0, $modelo->casilla('13'), 0.001);
+    }
+
+    public function testCompraInversionSujetoPasivo(): void
+    {
+        $modelo = new Modelo303();
+        // autorrepercusión: IVAREP (devengado) + IVASOP (deducible), mismo importe
+        $modelo->loadFromResumen([
+            $this->row('IVAREP', 21, 3000.0, 630.0, InvoiceOperation::REVERSE_CHARGE, 'compra'),
+            $this->row('IVASOP', 21, 3000.0, 630.0, InvoiceOperation::REVERSE_CHARGE, 'compra'),
+        ]);
+
+        // devengado -> 12/13
+        $this->assertEqualsWithDelta(3000.0, $modelo->casilla('12'), 0.001);
+        $this->assertEqualsWithDelta(630.0, $modelo->casilla('13'), 0.001);
+        // deducible -> 28/29
+        $this->assertEqualsWithDelta(3000.0, $modelo->casilla('28'), 0.001);
+        $this->assertEqualsWithDelta(630.0, $modelo->casilla('29'), 0.001);
+
+        // el IVA se compensa: resultado del régimen general (46) = 0
+        $this->assertEqualsWithDelta(0.0, $modelo->casilla('46'), 0.001);
+        // y NO debe contaminar las casillas de ventas nacionales (07/09)
+        $this->assertEqualsWithDelta(0.0, $modelo->casilla('09'), 0.001);
+    }
+
+    public function testCompraNacionalDeducible(): void
+    {
+        $modelo = new Modelo303();
+        $modelo->loadFromResumen([
+            $this->row('IVASOP', 21, 2000.0, 420.0, '', 'compra'),
+            // tipo no contemplado en el mapa antiguo (5%): debe sumarse igual via comodín
+            $this->row('IVASOP', 5, 100.0, 5.0, '', 'compra'),
+        ]);
+
+        $this->assertEqualsWithDelta(2100.0, $modelo->casilla('28'), 0.001);
+        $this->assertEqualsWithDelta(425.0, $modelo->casilla('29'), 0.001);
+        $this->assertEqualsWithDelta(425.0, $modelo->casilla('45'), 0.001);
+        $this->assertEmpty($modelo->getAvisos());
+    }
+
+    public function testImporteSinCasillaGeneraAviso(): void
+    {
+        $modelo = new Modelo303();
+        // cuenta especial desconocida con importe: debe generar aviso y no perderse en silencio
+        $modelo->loadFromResumen([
+            $this->row('IVAXXX', 21, 1000.0, 210.0, '', 'venta'),
+        ]);
+
+        $this->assertNotEmpty($modelo->getAvisos());
+    }
+
+    public function testRecargoEquivalencia(): void
+    {
+        $modelo = new Modelo303();
+        $modelo->loadFromResumen([
+            $this->row('IVARRE', 21, 1000.0, 52.0, '', 'venta', 5.2),
+        ]);
+
+        // recargo 5.2 -> base 22 / cuota 24
+        $this->assertEqualsWithDelta(1000.0, $modelo->casilla('22'), 0.001);
+        $this->assertEqualsWithDelta(52.0, $modelo->casilla('24'), 0.001);
+    }
+
+    public function testVentaIntracomunitariaNoContaminaRegimenGeneral(): void
+    {
+        $modelo = new Modelo303();
+        // una venta intracomunitaria genera IVARUE/IVASUE (neto cero); NO debe sumar en 10/11/36/37
+        $modelo->loadFromResumen([
+            $this->row('IVARUE', 21, 7000.0, 1470.0, InvoiceOperation::INTRA_COMMUNITY, 'venta'),
+            $this->row('IVASUE', 21, 7000.0, 1470.0, InvoiceOperation::INTRA_COMMUNITY, 'venta'),
+        ]);
+
+        $this->assertEqualsWithDelta(0.0, $modelo->casilla('10'), 0.001);
+        $this->assertEqualsWithDelta(0.0, $modelo->casilla('11'), 0.001);
+        $this->assertEqualsWithDelta(0.0, $modelo->casilla('36'), 0.001);
+        $this->assertEqualsWithDelta(0.0, $modelo->casilla('37'), 0.001);
+        $this->assertEqualsWithDelta(0.0, $modelo->casilla('46'), 0.001);
+    }
+
+    public function testVentaNacionalRegimenGeneral(): void
+    {
+        $modelo = new Modelo303();
+        $modelo->loadFromResumen([
+            $this->row('IVAREP', 21, 1000.0, 210.0),
+            $this->row('IVAREP', 10, 500.0, 50.0),
+            $this->row('IVAREP', 4, 100.0, 4.0),
+        ]);
+
+        // 21% -> base 07 / cuota 09
+        $this->assertEqualsWithDelta(1000.0, $modelo->casilla('07'), 0.001);
+        $this->assertEqualsWithDelta(210.0, $modelo->casilla('09'), 0.001);
+        // 10% -> base 04 / cuota 06
+        $this->assertEqualsWithDelta(500.0, $modelo->casilla('04'), 0.001);
+        $this->assertEqualsWithDelta(50.0, $modelo->casilla('06'), 0.001);
+        // 4% -> base 01 / cuota 03
+        $this->assertEqualsWithDelta(100.0, $modelo->casilla('01'), 0.001);
+        $this->assertEqualsWithDelta(4.0, $modelo->casilla('03'), 0.001);
+
+        // total devengado (casilla 27) = 210 + 50 + 4
+        $this->assertEqualsWithDelta(264.0, $modelo->casilla('27'), 0.001);
+        $this->assertEmpty($modelo->getAvisos());
+    }
+
+    /**
+     * Crea una fila equivalente a una de PartidaImpuestoResumen.
+     */
+    private function row(
+        string $codcuentaesp,
+        float  $iva,
+        float  $base,
+        float  $cuota,
+        string $operacion = '',
+        string $tipodoc = '',
+        float  $recargo = 0.0
+    ): object {
+        return (object)[
+            'codcuentaesp' => $codcuentaesp,
+            'operacion' => $operacion,
+            'tipodoc' => $tipodoc,
+            'iva' => $iva,
+            'recargo' => $recargo,
+            'baseimponible' => $base,
+            'cuota' => $cuota,
+        ];
+    }
+}

--- a/Translation/es_ES.json
+++ b/Translation/es_ES.json
@@ -21,5 +21,10 @@
     "year-model-390": "Año (modelo 390)",
     "deductible-vat-28": "por operaciones interiores corrientes",
     "deductible-vat-32": "por importaciones",
-    "deductible-vat-36": "por adquisiciones intracomunitarias"
+    "deductible-vat-36": "por adquisiciones intracomunitarias",
+    "info-operations-no-vat": "Operaciones sin repercusión de IVA (informativas)",
+    "intra-community-deliveries": "Entregas intracomunitarias de bienes y servicios",
+    "exports": "Exportaciones y operaciones asimiladas",
+    "sales-reverse-charge": "Ventas con inversión del sujeto pasivo",
+    "model303-amount-without-square": "Hay un importe que no se refleja en ninguna casilla del modelo 303: cuenta %type%, tipo %rate%%, operación %operation%, base %base%, cuota %quota%. Revise la configuración de cuentas especiales o el tipo de operación de la factura."
 }

--- a/View/Modelo303.html.twig
+++ b/View/Modelo303.html.twig
@@ -289,3 +289,44 @@
         </div>
     </div>
 </div>
+<div class="row">
+    <div class="col-12">
+        <div class="card shadow mb-3">
+            <div class="card-header">
+                <i class="fa-solid fa-circle-info me-2" aria-hidden="true"></i>{{ trans('info-operations-no-vat') }}
+            </div>
+            <table class="table table-bordered table-sm mb-0">
+                <thead class="text-center">
+                <tr>
+                    <th></th>
+                    <th></th>
+                    <th>{{ trans('tax-base') }}</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr>
+                    <td>{{ trans('intra-community-deliveries') }}</td>
+                    <td class="text-center">59</td>
+                    <td class="text-end">
+                        <strong>{{ fsc.modelo303.casillaStr('59') }}</strong>
+                    </td>
+                </tr>
+                <tr>
+                    <td>{{ trans('exports') }}</td>
+                    <td class="text-center">60</td>
+                    <td class="text-end">
+                        <strong>{{ fsc.modelo303.casillaStr('60') }}</strong>
+                    </td>
+                </tr>
+                <tr>
+                    <td>{{ trans('sales-reverse-charge') }}</td>
+                    <td class="text-center">122</td>
+                    <td class="text-end">
+                        <strong>{{ fsc.modelo303.casillaStr('122') }}</strong>
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>

--- a/View/Modelo303.html.twig
+++ b/View/Modelo303.html.twig
@@ -1,332 +1,354 @@
 <div class="row">
-    <div class="col-6">
-        <div class="card shadow mb-3">
-            <div class="card-header">
-                <i class="fa-solid fa-file-invoice-dollar me-2" aria-hidden="true"></i>{{ trans('vat-accrued') }}
-            </div>
-            <table class="table table-bordered table-sm">
-                <thead class="text-center">
-                <tr>
-                    <th></th>
-                    <th>{{ trans('tax-base') }}</th>
-                    <th></th>
-                    <th>{{ trans('type') }} %</th>
-                    <th></th>
-                    <th>{{ trans('quota') }}</th>
-                </tr>
-                </thead>
-                <tbody>
-                <tr>
-                    <td class="text-center">150</td>
-                    <td class="text-end">
-                        <strong>{{ fsc.modelo303.casillaStr('150') }}</strong></td>
-                    <td class="text-center">151</td>
-                    <td class="text-center">
-                        <strong>{{ fsc.modelo303.casillaStr('151', true) }}</strong></td>
-                    <td class="text-center">152</td>
-                    <td class="text-end">
-                        <strong>{{ fsc.modelo303.casillaStr('152') }}</strong></td>
-                </tr>
-                <tr>
-                    <td class="text-center">165</td>
-                    <td class="text-end">
-                        <strong>{{ fsc.modelo303.casillaStr('165') }}</strong></td>
-                    <td class="text-center">166</td>
-                    <td class="text-center">
-                        <strong>{{ fsc.modelo303.casillaStr('166') }}</strong></td>
-                    <td class="text-center">167</td>
-                    <td class="text-end">
-                        <strong>{{ fsc.modelo303.casillaStr('167') }}</strong></td>
-                </tr>
-                <tr>
-                    <td class="text-center">01</td>
-                    <td class="text-end">
-                        <strong>{{ fsc.modelo303.casillaStr('01') }}</strong>
-                    </td>
-                    <td class="text-center">02</td>
-                    <td class="text-center">
-                        <strong>{{ fsc.modelo303.casillaStr('02') }}</strong></td>
-                    <td class="text-center">03</td>
-                    <td class="text-end">
-                        <strong>{{ fsc.modelo303.casillaStr('03') }}</strong>
-                    </td>
-                </tr>
-                <tr>
-                    <td class="text-center">153</td>
-                    <td class="text-end">
-                        <strong>{{ fsc.modelo303.casillaStr('153') }}</strong></td>
-                    <td class="text-center">154</td>
-                    <td class="text-center">
-                        <strong>{{ fsc.modelo303.casillaStr('154') }}</strong></td>
-                    <td class="text-center">155</td>
-                    <td class="text-end">
-                        <strong>{{ fsc.modelo303.casillaStr('155') }}</strong></td>
-                </tr>
-                <tr>
-                    <td class="text-center">04</td>
-                    <td class="text-end">
-                        <strong>{{ fsc.modelo303.casillaStr('04') }}</strong>
-                    </td>
-                    <td class="text-center">05</td>
-                    <td class="text-center">
-                        <strong>{{ fsc.modelo303.casillaStr('05') }}</strong></td>
-                    <td class="text-center">06</td>
-                    <td class="text-end">
-                        <strong>{{ fsc.modelo303.casillaStr('06') }}</strong>
-                    </td>
-                </tr>
-                <tr>
-                    <td class="text-center">07</td>
-                    <td class="text-end">
-                        <strong>{{ fsc.modelo303.casillaStr('07') }}</strong>
-                    </td>
-                    <td class="text-center">08</td>
-                    <td class="text-center">
-                        <strong>{{ fsc.modelo303.casillaStr('08') }}</strong></td>
-                    <td class="text-center">09</td>
-                    <td class="text-end">
-                        <strong>{{ fsc.modelo303.casillaStr('09') }}</strong>
-                    </td>
-                </tr>
-                <tr>
-                    <td class="text-center">10</td>
-                    <td class="text-end">
-                        <strong>{{ fsc.modelo303.casillaStr('10') }}</strong>
-                    </td>
-                    <td colspan="2" class="bg-light"></td>
-                    <td class="text-center">11</td>
-                    <td class="text-end">
-                        <strong>{{ fsc.modelo303.casillaStr('11') }}</strong>
-                    </td>
-                </tr>
-                <tr>
-                    <td class="text-center">12</td>
-                    <td class="text-end">
-                        <strong>{{ fsc.modelo303.casillaStr('12') }}</strong>
-                    </td>
-                    <td colspan="2" class="bg-light"></td>
-                    <td class="text-center">13</td>
-                    <td class="text-end">
-                        <strong>{{ fsc.modelo303.casillaStr('13') }}</strong>
-                    </td>
-                </tr>
-                <tr>
-                    <td class="text-center">14</td>
-                    <td class="text-end">
-                        <strong>{{ fsc.modelo303.casillaStr('14') }}</strong>
-                    </td>
-                    <td colspan="2" class="bg-light"></td>
-                    <td class="text-center">15</td>
-                    <td class="text-end">
-                        <strong>{{ fsc.modelo303.casillaStr('15') }}</strong>
-                    </td>
-                </tr>
-                <tr>
-                    <td class="text-center">156</td>
-                    <td class="text-end">
-                        <strong>{{ fsc.modelo303.casillaStr('156') }}</strong></td>
-                    <td class="text-center">157</td>
-                    <td class="text-center">
-                        <strong>{{ fsc.modelo303.casillaStr('157') }}</strong></td>
-                    <td class="text-center">158</td>
-                    <td class="text-end">
-                        <strong>{{ fsc.modelo303.casillaStr('158') }}</strong></td>
-                </tr>
-                <tr>
-                    <td class="text-center">168</td>
-                    <td class="text-end">
-                        <strong>{{ fsc.modelo303.casillaStr('168') }}</strong></td>
-                    <td class="text-center">169</td>
-                    <td class="text-center">
-                        <strong>{{ fsc.modelo303.casillaStr('169') }}</strong></td>
-                    <td class="text-center">170</td>
-                    <td class="text-end">
-                        <strong>{{ fsc.modelo303.casillaStr('170') }}</strong></td>
-                </tr>
-                <tr>
-                    <td class="text-center">16</td>
-                    <td class="text-end">
-                        <strong>{{ fsc.modelo303.casillaStr('16') }}</strong>
-                    </td>
-                    <td class="text-center">17</td>
-                    <td class="text-center">
-                        <strong>{{ fsc.modelo303.casillaStr('17') }}</strong></td>
-                    <td class="text-center">18</td>
-                    <td class="text-end">
-                        <strong>{{ fsc.modelo303.casillaStr('18') }}</strong>
-                    </td>
-                </tr>
-                <tr>
-                    <td class="text-center">19</td>
-                    <td class="text-end">
-                        <strong>{{ fsc.modelo303.casillaStr('19') }}</strong>
-                    </td>
-                    <td class="text-center">20</td>
-                    <td class="text-center">
-                        <strong>{{ fsc.modelo303.casillaStr('20') }}</strong></td>
-                    <td class="text-center">21</td>
-                    <td class="text-end">
-                        <strong>{{ fsc.modelo303.casillaStr('21') }}</strong>
-                    </td>
-                </tr>
-                <tr>
-                    <td class="text-center">22</td>
-                    <td class="text-end">
-                        <strong>{{ fsc.modelo303.casillaStr('22') }}</strong>
-                    </td>
-                    <td class="text-center">23</td>
-                    <td class="text-center">
-                        <strong>{{ fsc.modelo303.casillaStr('23') }}</strong></td>
-                    <td class="text-center">24</td>
-                    <td class="text-end">
-                        <strong>{{ fsc.modelo303.casillaStr('24') }}</strong>
-                    </td>
-                </tr>
-                <tr>
-                    <td class="text-center">25</td>
-                    <td class="text-end">
-                        <strong>{{ fsc.modelo303.casillaStr('25') }}</strong>
-                    </td>
-                    <td colspan="2" class="bg-light"></td>
-                    <td class="text-center">26</td>
-                    <td class="text-end">
-                        <strong>{{ fsc.modelo303.casillaStr('26') }}</strong>
-                    </td>
-                </tr>
-                </tbody>
-            </table>
-            <table class="table table-bordered table-sm mb-0">
-                <tbody>
-                <tr>
-                    <td>{{ trans('total-accrued-fee') }}</td>
-                    <td class="text-center">27</td>
-                    <td class="text-end">
-                        <strong>{{ fsc.modelo303.casillaStr('27') }}</strong>
-                    </td>
-                </tr>
-                </tbody>
-            </table>
-        </div>
-    </div>
-    <div class="col-6">
-        <div class="card shadow mb-3">
-            <div class="card-header">
-                <i class="fa-solid fa-arrow-down me-2" aria-hidden="true"></i>{{ trans('deductible-vat') }}
-            </div>
-            <table class="table table-bordered table-sm">
-                <thead class="text-center">
-                <tr>
-                    <th></th>
-                    <th></th>
-                    <th>{{ trans('base') }}</th>
-                    <th></th>
-                    <th>{{ trans('quota') }}</th>
-                </tr>
-                </thead>
-                <tbody>
-                <tr>
-                    <td>{{ trans('deductible-vat-28') }}</td>
-                    <td class="text-center">28</td>
-                    <td class="text-end">
-                        <strong>{{ fsc.modelo303.casillaStr('28') }}</strong>
-                    </td>
-                    <td class="text-center">29</td>
-                    <td class="text-end">
-                        <strong>{{ fsc.modelo303.casillaStr('29') }}</strong>
-                    </td>
-                </tr>
-                <tr>
-                    <td>{{ trans('deductible-vat-32') }}</td>
-                    <td class="text-center">32</td>
-                    <td class="text-end">
-                        <strong>{{ fsc.modelo303.casillaStr('32') }}</strong>
-                    </td>
-                    <td class="text-center">33</td>
-                    <td class="text-end">
-                        <strong>{{ fsc.modelo303.casillaStr('33') }}</strong>
-                    </td>
-                </tr>
-                <tr>
-                    <td>{{ trans('deductible-vat-36') }}</td>
-                    <td class="text-center">36</td>
-                    <td class="text-end">
-                        <strong>{{ fsc.modelo303.casillaStr('36') }}</strong>
-                    </td>
-                    <td class="text-center">37</td>
-                    <td class="text-end">
-                        <strong>{{ fsc.modelo303.casillaStr('37') }}</strong>
-                    </td>
-                </tr>
-                </tbody>
-            </table>
-            <table class="table table-bordered table-sm mb-0">
-                <tbody>
-                <tr>
-                    <td>{{ trans('total-to-deduct') }}</td>
-                    <td class="text-center">45</td>
-                    <td class="text-end">
-                        <strong>{{ fsc.modelo303.casillaStr('45') }}</strong>
-                    </td>
-                </tr>
-                </tbody>
-            </table>
-        </div>
-        <div class="card border-success shadow">
-            <div class="card-header bg-success text-white fw-bold">
-                <i class="fa-solid fa-calculator me-2" aria-hidden="true"></i>{{ trans('general-regime-result') }}
-            </div>
-            <table class="table table-bordered table-sm mb-0">
-                <tbody>
-                <tr class="table-success fw-bold">
-                    <td class="align-middle">{{ trans('total-result-of-the-general-regime') }}</td>
-                    <td class="text-center align-middle">46</td>
-                    <td class="text-end">
-                        <strong class="fs-4 text-success">{{ fsc.modelo303.casillaStr('46') }}</strong>
-                    </td>
-                </tr>
-                </tbody>
-            </table>
-        </div>
-    </div>
-</div>
-<div class="row">
-    <div class="col-12">
-        <div class="card shadow mb-3">
-            <div class="card-header">
-                <i class="fa-solid fa-circle-info me-2" aria-hidden="true"></i>{{ trans('info-operations-no-vat') }}
-            </div>
-            <table class="table table-bordered table-sm mb-0">
-                <thead class="text-center">
-                <tr>
-                    <th></th>
-                    <th></th>
-                    <th>{{ trans('tax-base') }}</th>
-                </tr>
-                </thead>
-                <tbody>
-                <tr>
-                    <td>{{ trans('intra-community-deliveries') }}</td>
-                    <td class="text-center">59</td>
-                    <td class="text-end">
-                        <strong>{{ fsc.modelo303.casillaStr('59') }}</strong>
-                    </td>
-                </tr>
-                <tr>
-                    <td>{{ trans('exports') }}</td>
-                    <td class="text-center">60</td>
-                    <td class="text-end">
-                        <strong>{{ fsc.modelo303.casillaStr('60') }}</strong>
-                    </td>
-                </tr>
-                <tr>
-                    <td>{{ trans('sales-reverse-charge') }}</td>
-                    <td class="text-center">122</td>
-                    <td class="text-end">
-                        <strong>{{ fsc.modelo303.casillaStr('122') }}</strong>
-                    </td>
-                </tr>
-                </tbody>
-            </table>
-        </div>
-    </div>
+	<div class="col-6">
+		<div class="card shadow mb-3">
+			<div class="card-header">
+				<i class="fa-solid fa-file-invoice-dollar me-2" aria-hidden="true"></i>
+				{{ trans('vat-accrued') }}
+			</div>
+			<table class="table table-bordered table-sm">
+				<thead class="text-center">
+					<tr>
+						<th></th>
+						<th>{{ trans('tax-base') }}</th>
+						<th></th>
+						<th>{{ trans('type') }}
+							%</th>
+						<th></th>
+						<th>{{ trans('quota') }}</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<td class="text-center">150</td>
+						<td class="text-end">
+							<strong>{{ fsc.modelo303.casillaStr('150') }}</strong>
+						</td>
+						<td class="text-center">151</td>
+						<td class="text-center">
+							<strong>{{ fsc.modelo303.casillaStr('151', true) }}</strong>
+						</td>
+						<td class="text-center">152</td>
+						<td class="text-end">
+							<strong>{{ fsc.modelo303.casillaStr('152') }}</strong>
+						</td>
+					</tr>
+					<tr>
+						<td class="text-center">165</td>
+						<td class="text-end">
+							<strong>{{ fsc.modelo303.casillaStr('165') }}</strong>
+						</td>
+						<td class="text-center">166</td>
+						<td class="text-center">
+							<strong>{{ fsc.modelo303.casillaStr('166') }}</strong>
+						</td>
+						<td class="text-center">167</td>
+						<td class="text-end">
+							<strong>{{ fsc.modelo303.casillaStr('167') }}</strong>
+						</td>
+					</tr>
+					<tr>
+						<td class="text-center">01</td>
+						<td class="text-end">
+							<strong>{{ fsc.modelo303.casillaStr('01') }}</strong>
+						</td>
+						<td class="text-center">02</td>
+						<td class="text-center">
+							<strong>{{ fsc.modelo303.casillaStr('02') }}</strong>
+						</td>
+						<td class="text-center">03</td>
+						<td class="text-end">
+							<strong>{{ fsc.modelo303.casillaStr('03') }}</strong>
+						</td>
+					</tr>
+					<tr>
+						<td class="text-center">153</td>
+						<td class="text-end">
+							<strong>{{ fsc.modelo303.casillaStr('153') }}</strong>
+						</td>
+						<td class="text-center">154</td>
+						<td class="text-center">
+							<strong>{{ fsc.modelo303.casillaStr('154') }}</strong>
+						</td>
+						<td class="text-center">155</td>
+						<td class="text-end">
+							<strong>{{ fsc.modelo303.casillaStr('155') }}</strong>
+						</td>
+					</tr>
+					<tr>
+						<td class="text-center">04</td>
+						<td class="text-end">
+							<strong>{{ fsc.modelo303.casillaStr('04') }}</strong>
+						</td>
+						<td class="text-center">05</td>
+						<td class="text-center">
+							<strong>{{ fsc.modelo303.casillaStr('05') }}</strong>
+						</td>
+						<td class="text-center">06</td>
+						<td class="text-end">
+							<strong>{{ fsc.modelo303.casillaStr('06') }}</strong>
+						</td>
+					</tr>
+					<tr>
+						<td class="text-center">07</td>
+						<td class="text-end">
+							<strong>{{ fsc.modelo303.casillaStr('07') }}</strong>
+						</td>
+						<td class="text-center">08</td>
+						<td class="text-center">
+							<strong>{{ fsc.modelo303.casillaStr('08') }}</strong>
+						</td>
+						<td class="text-center">09</td>
+						<td class="text-end">
+							<strong>{{ fsc.modelo303.casillaStr('09') }}</strong>
+						</td>
+					</tr>
+					<tr>
+						<td class="text-center">10</td>
+						<td class="text-end">
+							<strong>{{ fsc.modelo303.casillaStr('10') }}</strong>
+						</td>
+						<td colspan="2" class="bg-light"></td>
+						<td class="text-center">11</td>
+						<td class="text-end">
+							<strong>{{ fsc.modelo303.casillaStr('11') }}</strong>
+						</td>
+					</tr>
+					<tr>
+						<td class="text-center">12</td>
+						<td class="text-end">
+							<strong>{{ fsc.modelo303.casillaStr('12') }}</strong>
+						</td>
+						<td colspan="2" class="bg-light"></td>
+						<td class="text-center">13</td>
+						<td class="text-end">
+							<strong>{{ fsc.modelo303.casillaStr('13') }}</strong>
+						</td>
+					</tr>
+					<tr>
+						<td class="text-center">14</td>
+						<td class="text-end">
+							<strong>{{ fsc.modelo303.casillaStr('14') }}</strong>
+						</td>
+						<td colspan="2" class="bg-light"></td>
+						<td class="text-center">15</td>
+						<td class="text-end">
+							<strong>{{ fsc.modelo303.casillaStr('15') }}</strong>
+						</td>
+					</tr>
+					<tr>
+						<td class="text-center">156</td>
+						<td class="text-end">
+							<strong>{{ fsc.modelo303.casillaStr('156') }}</strong>
+						</td>
+						<td class="text-center">157</td>
+						<td class="text-center">
+							<strong>{{ fsc.modelo303.casillaStr('157') }}</strong>
+						</td>
+						<td class="text-center">158</td>
+						<td class="text-end">
+							<strong>{{ fsc.modelo303.casillaStr('158') }}</strong>
+						</td>
+					</tr>
+					<tr>
+						<td class="text-center">168</td>
+						<td class="text-end">
+							<strong>{{ fsc.modelo303.casillaStr('168') }}</strong>
+						</td>
+						<td class="text-center">169</td>
+						<td class="text-center">
+							<strong>{{ fsc.modelo303.casillaStr('169') }}</strong>
+						</td>
+						<td class="text-center">170</td>
+						<td class="text-end">
+							<strong>{{ fsc.modelo303.casillaStr('170') }}</strong>
+						</td>
+					</tr>
+					<tr>
+						<td class="text-center">16</td>
+						<td class="text-end">
+							<strong>{{ fsc.modelo303.casillaStr('16') }}</strong>
+						</td>
+						<td class="text-center">17</td>
+						<td class="text-center">
+							<strong>{{ fsc.modelo303.casillaStr('17') }}</strong>
+						</td>
+						<td class="text-center">18</td>
+						<td class="text-end">
+							<strong>{{ fsc.modelo303.casillaStr('18') }}</strong>
+						</td>
+					</tr>
+					<tr>
+						<td class="text-center">19</td>
+						<td class="text-end">
+							<strong>{{ fsc.modelo303.casillaStr('19') }}</strong>
+						</td>
+						<td class="text-center">20</td>
+						<td class="text-center">
+							<strong>{{ fsc.modelo303.casillaStr('20') }}</strong>
+						</td>
+						<td class="text-center">21</td>
+						<td class="text-end">
+							<strong>{{ fsc.modelo303.casillaStr('21') }}</strong>
+						</td>
+					</tr>
+					<tr>
+						<td class="text-center">22</td>
+						<td class="text-end">
+							<strong>{{ fsc.modelo303.casillaStr('22') }}</strong>
+						</td>
+						<td class="text-center">23</td>
+						<td class="text-center">
+							<strong>{{ fsc.modelo303.casillaStr('23') }}</strong>
+						</td>
+						<td class="text-center">24</td>
+						<td class="text-end">
+							<strong>{{ fsc.modelo303.casillaStr('24') }}</strong>
+						</td>
+					</tr>
+					<tr>
+						<td class="text-center">25</td>
+						<td class="text-end">
+							<strong>{{ fsc.modelo303.casillaStr('25') }}</strong>
+						</td>
+						<td colspan="2" class="bg-light"></td>
+						<td class="text-center">26</td>
+						<td class="text-end">
+							<strong>{{ fsc.modelo303.casillaStr('26') }}</strong>
+						</td>
+					</tr>
+				</tbody>
+			</table>
+			<table class="table table-bordered table-sm mb-0">
+				<tbody>
+					<tr>
+						<td>{{ trans('total-accrued-fee') }}</td>
+						<td class="text-center">27</td>
+						<td class="text-end">
+							<strong>{{ fsc.modelo303.casillaStr('27') }}</strong>
+						</td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+	</div>
+	<div class="col-6">
+		<div class="card shadow mb-3">
+			<div class="card-header">
+				<i class="fa-solid fa-arrow-down me-2" aria-hidden="true"></i>
+				{{ trans('deductible-vat') }}
+			</div>
+			<table class="table table-bordered table-sm">
+				<thead class="text-center">
+					<tr>
+						<th></th>
+						<th></th>
+						<th>{{ trans('base') }}</th>
+						<th></th>
+						<th>{{ trans('quota') }}</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<td>{{ trans('deductible-vat-28') }}</td>
+						<td class="text-center">28</td>
+						<td class="text-end">
+							<strong>{{ fsc.modelo303.casillaStr('28') }}</strong>
+						</td>
+						<td class="text-center">29</td>
+						<td class="text-end">
+							<strong>{{ fsc.modelo303.casillaStr('29') }}</strong>
+						</td>
+					</tr>
+					<tr>
+						<td>{{ trans('deductible-vat-32') }}</td>
+						<td class="text-center">32</td>
+						<td class="text-end">
+							<strong>{{ fsc.modelo303.casillaStr('32') }}</strong>
+						</td>
+						<td class="text-center">33</td>
+						<td class="text-end">
+							<strong>{{ fsc.modelo303.casillaStr('33') }}</strong>
+						</td>
+					</tr>
+					<tr>
+						<td>{{ trans('deductible-vat-36') }}</td>
+						<td class="text-center">36</td>
+						<td class="text-end">
+							<strong>{{ fsc.modelo303.casillaStr('36') }}</strong>
+						</td>
+						<td class="text-center">37</td>
+						<td class="text-end">
+							<strong>{{ fsc.modelo303.casillaStr('37') }}</strong>
+						</td>
+					</tr>
+				</tbody>
+			</table>
+			<table class="table table-bordered table-sm mb-0">
+				<tbody>
+					<tr>
+						<td>{{ trans('total-to-deduct') }}</td>
+						<td class="text-center">45</td>
+						<td class="text-end">
+							<strong>{{ fsc.modelo303.casillaStr('45') }}</strong>
+						</td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+		<div class="card border-success shadow mb-3">
+			<div class="card-header bg-success text-white fw-bold">
+				<i class="fa-solid fa-calculator me-2" aria-hidden="true"></i>
+				{{ trans('general-regime-result') }}
+			</div>
+			<table class="table table-bordered table-sm mb-0">
+				<tbody>
+					<tr class="table-success fw-bold">
+						<td class="align-middle">{{ trans('total-result-of-the-general-regime') }}</td>
+						<td class="text-center align-middle">46</td>
+						<td class="text-end">
+							<strong class="fs-4 text-success">{{ fsc.modelo303.casillaStr('46') }}</strong>
+						</td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+			<div class="card shadow">
+				<div class="card-header">
+					<i class="fa-solid fa-circle-info me-2" aria-hidden="true"></i>
+					{{ trans('info-operations-no-vat') }}
+				</div>
+				<table class="table table-bordered table-sm mb-0">
+					<thead class="text-center">
+						<tr>
+							<th></th>
+							<th></th>
+							<th>{{ trans('tax-base') }}</th>
+						</tr>
+					</thead>
+					<tbody>
+						<tr>
+							<td>{{ trans('intra-community-deliveries') }}</td>
+							<td class="text-center">59</td>
+							<td class="text-end">
+								<strong>{{ fsc.modelo303.casillaStr('59') }}</strong>
+							</td>
+						</tr>
+						<tr>
+							<td>{{ trans('exports') }}</td>
+							<td class="text-center">60</td>
+							<td class="text-end">
+								<strong>{{ fsc.modelo303.casillaStr('60') }}</strong>
+							</td>
+						</tr>
+						<tr>
+							<td>{{ trans('sales-reverse-charge') }}</td>
+							<td class="text-center">122</td>
+							<td class="text-end">
+								<strong>{{ fsc.modelo303.casillaStr('122') }}</strong>
+							</td>
+						</tr>
+					</tbody>
+				</table>
+			</div>
+	</div>
 </div>


### PR DESCRIPTION
## Descripción
Resuelve dos problemas relacionados del Modelo 303 que comparten los mismos archivos:

1. **Desfase de céntimos entre pestañas.** Las pestañas Resumen, Compras/Ventas y Cuentas no cuadraban porque usaban tres consultas distintas, con filtros y cálculo de la cuota diferentes.
2. **Casillas incorrectas según el tipo de operación (tarea 4542).** El reparto a casillas se decidía solo por la cuenta especial y el tipo impositivo, ignorando la operación de la factura. Una compra con *inversión del sujeto pasivo* caía en las casillas de ventas nacionales (07/09) en lugar de 12/13 + 28/29, y las intracomunitarias no se separaban bien.

Sustituye al **PR #21**, corrigiendo además el mapeo de intracomunitarias que aquel resolvía mal (las enviaba a 12/13 + 28/29 cuando deben ir a 10/11 + 36/37), siguiendo las indicaciones del revisor en ese PR.

## Tarea relacionada
[Tarea #4542](https://facturascripts.com/roadmap/4542)

## Cambios realizados

**Unificación de datos y redondeo:**
- `EditRegularizacionImpuesto`: criterio común `commonTaxWhere` para las tres consultas (misma empresa+ejercicio+fechas, exclusión de todos los asientos de regularización, `series.siniva=false`, exclusión de apertura/cierre y selección de cuentas por **grupo de cuenta especial** en vez de `LIKE 477%/472%`).
- `PartidaImpuesto`: la cuota es siempre el **importe contable real** (`debe`/`haber` con corrección de signo en bases negativas), nunca un recálculo `base×tipo`.
- `VatRegularizationToAccounting::getSubtotals`: alineado con el mismo criterio.

**Mapeo por tipo de operación:**
- `PartidaImpuestoResumen`: añade `operacion` (JOIN por `idasiento` mediante subconsultas que solo exponen `idasiento` y `operacion`, evitando columnas ambiguas) y `tipodoc` (compra/venta).
- `Modelo303`: enrutado por operación → ISP `12/13 + 28/29`; intracomunitarias/servicios `10/11 + 36/37`; importación `32/33`; ventas exentas (intracom `59`, exportación `60`, ISP `122`) desde las facturas. Las partidas net-zero de ventas intracomunitarias se excluyen del régimen general. Comodines en `casillaMap` y **avisos** cuando un importe no encaja en ninguna casilla.
- Vista: muestra las casillas informativas 59, 60 y 122.

## Cómo probar
- Tests: `vendor/bin/phpunit Plugins/Modelo303/Test` (incluye `Modelo303SquaresTest` que cubre nacional, ISP, intracomunitaria genérica y específica, importación, venta intracom que no contamina, recargo, tasa no mapeada y avisos).
- Manual: en una regularización con facturas de compra marcadas como *inversión del sujeto pasivo* e *intracomunitarias*, comprobar que el Resumen cuadra con Compras/Ventas y con el asiento, y que las casillas 12/13, 28/29, 10/11, 36/37, 59, 60 y 122 se rellenan según corresponde.

## Notas
- La casilla 77 (IVA devengado de importación, liquidado por aduana) no tiene origen contable automático en FacturaScripts; queda documentada en el código.

🤖 Generated with [Claude Code](https://claude.com/claude-code)