### PR TITLE
Ajuste impuestos especiales

### DIFF
--- a/Lib/Modelo303.php
+++ b/Lib/Modelo303.php
@@ -56,7 +56,8 @@ class Modelo303
         'IVAREP' => [
             '2'   => ['base' => '165', 'cuota' => '167'],
             '4'   => ['base' => '01', 'cuota' => '03'],
-            '7.5' => ['base' => '153', 'cuota' => '155'],
+            '5'   => ['base' => '153', 'cuota' => '155'],
+            '7.5' => ['base' => '162', 'cuota' => '164'],
             '10'  => ['base' => '04', 'cuota' => '06'],
             '21'  => ['base' => '07', 'cuota' => '09'],
         ],
@@ -124,8 +125,9 @@ class Modelo303
         $this->square['17'] = 1.00;
         $this->square['20'] = 1.40;
         $this->square['23'] = 5.20;
-        $this->square['154'] = 7.50;
+        $this->square['154'] = 5.00;
         $this->square['157'] = 1.75;
+        $this->square['163'] = 7.50;
         $this->square['169'] = 0.26;
         $this->square['166'] = 2.00;
     }
@@ -234,6 +236,56 @@ class Modelo303
             'iva-soportado' => static::treasurySaldoCuenta('472%', $dateStart, $dateEnd, $dataBase),
             'iva-devolver' => static::treasurySaldoCuenta('4700%', $dateStart, $dateEnd, $dataBase),
         ];
+    }
+
+    protected static function treasuryDates(Ejercicio $exercise, string $period): array
+    {
+        // si el periodo no es T1, T2, T3, T4 o Annual, se asume que es el primer trimestre
+        if (!in_array($period, ['T1', 'T2', 'T3', 'T4', 'ANNUAL'])) {
+            $period = 'T1';
+        }
+
+        return match ($period) {
+            'T1' => [
+                date('01-01-Y', strtotime($exercise->fechainicio)),
+                date('31-03-Y', strtotime($exercise->fechainicio))
+            ],
+            'T2' => [
+                date('01-04-Y', strtotime($exercise->fechainicio)),
+                date('30-06-Y', strtotime($exercise->fechainicio))
+            ],
+            'T3' => [
+                date('01-07-Y', strtotime($exercise->fechainicio)),
+                date('30-09-Y', strtotime($exercise->fechainicio))
+            ],
+            'ANNUAL' => [
+                date('01-01-Y', strtotime($exercise->fechainicio)),
+                date('31-12-Y', strtotime($exercise->fechainicio))
+            ],
+            default => [
+                date('01-10-Y', strtotime($exercise->fechainicio)),
+                date('31-12-Y', strtotime($exercise->fechainicio))
+            ],
+        };
+    }
+
+    protected static function treasurySaldoCuenta(string $cuenta, string $desde, string $hasta, DataBase $dataBase): float
+    {
+        $saldo = 0.0;
+
+        if ($dataBase->tableExists('partidas')) {
+            // calculamos el saldo de todos aquellos asientos que afecten a caja
+            $sql = "select sum(debe-haber) as total from partidas where codsubcuenta LIKE " . $dataBase->var2str($cuenta)
+                . " and idasiento in (select idasiento from asientos where fecha >= " . $dataBase->var2str($desde)
+                . " and fecha <= " . $dataBase->var2str($hasta) . ");";
+
+            $data = $dataBase->select($sql);
+            if ($data && $data[0]['total'] !== null) {
+                $saldo = floatval($data[0]['total']);
+            }
+        }
+
+        return $saldo;
     }
 
     /**
@@ -452,55 +504,5 @@ class Modelo303
             '%base%' => Tools::number($base, 2),
             '%quota%' => Tools::number($cuota, 2),
         ]);
-    }
-
-    protected static function treasuryDates(Ejercicio $exercise, string $period): array
-    {
-        // si el periodo no es T1, T2, T3, T4 o Annual, se asume que es el primer trimestre
-        if (!in_array($period, ['T1', 'T2', 'T3', 'T4', 'ANNUAL'])) {
-            $period = 'T1';
-        }
-
-        return match ($period) {
-            'T1' => [
-                date('01-01-Y', strtotime($exercise->fechainicio)),
-                date('31-03-Y', strtotime($exercise->fechainicio))
-            ],
-            'T2' => [
-                date('01-04-Y', strtotime($exercise->fechainicio)),
-                date('30-06-Y', strtotime($exercise->fechainicio))
-            ],
-            'T3' => [
-                date('01-07-Y', strtotime($exercise->fechainicio)),
-                date('30-09-Y', strtotime($exercise->fechainicio))
-            ],
-            'ANNUAL' => [
-                date('01-01-Y', strtotime($exercise->fechainicio)),
-                date('31-12-Y', strtotime($exercise->fechainicio))
-            ],
-            default => [
-                date('01-10-Y', strtotime($exercise->fechainicio)),
-                date('31-12-Y', strtotime($exercise->fechainicio))
-            ],
-        };
-    }
-
-    protected static function treasurySaldoCuenta(string $cuenta, string $desde, string $hasta, DataBase $dataBase): float
-    {
-        $saldo = 0.0;
-
-        if ($dataBase->tableExists('partidas')) {
-            // calculamos el saldo de todos aquellos asientos que afecten a caja
-            $sql = "select sum(debe-haber) as total from partidas where codsubcuenta LIKE " . $dataBase->var2str($cuenta)
-                . " and idasiento in (select idasiento from asientos where fecha >= " . $dataBase->var2str($desde)
-                . " and fecha <= " . $dataBase->var2str($hasta) . ");";
-
-            $data = $dataBase->select($sql);
-            if ($data && $data[0]['total'] !== null) {
-                $saldo = floatval($data[0]['total']);
-            }
-        }
-
-        return $saldo;
     }
 }

--- a/View/Modelo303.html.twig
+++ b/View/Modelo303.html.twig
@@ -32,6 +32,7 @@
 							<strong>{{ fsc.modelo303.casillaStr('152') }}</strong>
 						</td>
 					</tr>
+					{% if fsc.modelo303.casilla('165') or fsc.modelo303.casilla('167') %}
 					<tr>
 						<td class="text-center">165</td>
 						<td class="text-end">
@@ -46,6 +47,7 @@
 							<strong>{{ fsc.modelo303.casillaStr('167') }}</strong>
 						</td>
 					</tr>
+					{% endif %}
 					<tr>
 						<td class="text-center">01</td>
 						<td class="text-end">
@@ -60,6 +62,7 @@
 							<strong>{{ fsc.modelo303.casillaStr('03') }}</strong>
 						</td>
 					</tr>
+					{% if fsc.modelo303.casilla('153') or fsc.modelo303.casilla('155') %}
 					<tr>
 						<td class="text-center">153</td>
 						<td class="text-end">
@@ -74,6 +77,23 @@
 							<strong>{{ fsc.modelo303.casillaStr('155') }}</strong>
 						</td>
 					</tr>
+					{% endif %}
+					{% if fsc.modelo303.casilla('162') or fsc.modelo303.casilla('164') %}
+					<tr>
+						<td class="text-center">162</td>
+						<td class="text-end">
+							<strong>{{ fsc.modelo303.casillaStr('162') }}</strong>
+						</td>
+						<td class="text-center">163</td>
+						<td class="text-center">
+							<strong>{{ fsc.modelo303.casillaStr('163') }}</strong>
+						</td>
+						<td class="text-center">164</td>
+						<td class="text-end">
+							<strong>{{ fsc.modelo303.casillaStr('164') }}</strong>
+						</td>
+					</tr>
+					{% endif %}
 					<tr>
 						<td class="text-center">04</td>
 						<td class="text-end">
@@ -135,6 +155,7 @@
 							<strong>{{ fsc.modelo303.casillaStr('15') }}</strong>
 						</td>
 					</tr>
+					{% if fsc.modelo303.casilla('156') or fsc.modelo303.casilla('158') %}
 					<tr>
 						<td class="text-center">156</td>
 						<td class="text-end">
@@ -149,6 +170,8 @@
 							<strong>{{ fsc.modelo303.casillaStr('158') }}</strong>
 						</td>
 					</tr>
+					{% endif %}
+					{% if fsc.modelo303.casilla('168') or fsc.modelo303.casilla('170') %}
 					<tr>
 						<td class="text-center">168</td>
 						<td class="text-end">
@@ -163,6 +186,7 @@
 							<strong>{{ fsc.modelo303.casillaStr('170') }}</strong>
 						</td>
 					</tr>
+					{% endif %}
 					<tr>
 						<td class="text-center">16</td>
 						<td class="text-end">


### PR DESCRIPTION
- 5% → casillas 153 (base) / 154 (tipo fijo 5,00) / 155 (cuota)
- 7,5% → casillas 162 (base) / 163 (tipo fijo 7,50) / 164 (cuota)
- Filas ocultas cuando están a cero: 2%, 5%, 7,5% (IVAREP) y los recargos especiales 1,75% y 0,26%