### PR TITLE
Corrección de la imputación de facturas exentas al 0% de IVA

### DIFF
--- a/Lib/Modelo303.php
+++ b/Lib/Modelo303.php
@@ -49,11 +49,19 @@ class Modelo303
      * @var array<string, array<string, array<string, ?string>>>
      */
     private array $casillaMap = [
+
+        /***********************************
+        *      OPERACIONES DE VENTAS      *
+        ***********************************/
+
         /*
          * IVA devengado (repercutido).
          * Ventas nacionales (régimen general)
          */
         'IVAREP' => [
+            // El tipo 0% va a la casilla 150 (exentas), igual que en en la cuenta especial IVAREX,
+            // por si la subcuenta del impuesto no está marcada como cuenta especial de exentas en el plan contable
+            '0'   => ['base' => '150', 'cuota' => null],
             '2'   => ['base' => '165', 'cuota' => '167'],
             '4'   => ['base' => '01', 'cuota' => '03'],
             '5'   => ['base' => '153', 'cuota' => '155'],
@@ -79,11 +87,19 @@ class Modelo303
         // Operaciones exentas
         'IVAREX' => ['*' => ['base' => '150', 'cuota' => null]],
 
+
+        /***********************************
+        *      OPERACIONES DE COMPRAS      *
+        ***********************************/
+
         /*
          * IVA soportado (deducible)
          * Compras nacionales (régimen general)
          */
         'IVASOP' => [
+            // El tipo 0% se descarta, igual que en en la cuenta especial IVASEX,
+            // por si la subcuenta del impuesto no está marcada como cuenta especial de exentas en el plan contable
+            '0' => ['base' => null, 'cuota' => null], 
             '*' => ['base' => '28', 'cuota' => '29'],
         ],
 

--- a/Test/main/Modelo303SquaresTest.php
+++ b/Test/main/Modelo303SquaresTest.php
@@ -114,6 +114,21 @@ final class Modelo303SquaresTest extends TestCase
         $this->assertEmpty($modelo->getAvisos());
     }
 
+    public function testCompraExentaNoContaminaRegimenGeneral(): void
+    {
+        $modelo = new Modelo303();
+        // Compra exenta (0%): no debe imputarse en 28/29 del régimen general
+        $modelo->loadFromResumen([
+            $this->row('IVASOP', 0, 1500.0, 0.0, '', 'compra'),
+            $this->row('IVASEX', 0, 800.0, 0.0, '', 'compra'),
+        ]);
+
+        $this->assertEqualsWithDelta(0.0, $modelo->casilla('28'), 0.001);
+        $this->assertEqualsWithDelta(0.0, $modelo->casilla('29'), 0.001);
+        $this->assertEqualsWithDelta(0.0, $modelo->casilla('45'), 0.001);
+        $this->assertEmpty($modelo->getAvisos());
+    }
+
     public function testImporteSinCasillaGeneraAviso(): void
     {
         $modelo = new Modelo303();
@@ -160,6 +175,8 @@ final class Modelo303SquaresTest extends TestCase
             $this->row('IVAREP', 21, 1000.0, 210.0),
             $this->row('IVAREP', 10, 500.0, 50.0),
             $this->row('IVAREP', 4, 100.0, 4.0),
+            $this->row('IVAREP', 0, 10.0, 0.0, '', 'venta'),
+            $this->row('IVAREX', 0, 500.0, 0.0, '', 'venta'),
         ]);
 
         // 21% -> base 07 / cuota 09
@@ -171,6 +188,8 @@ final class Modelo303SquaresTest extends TestCase
         // 4% -> base 01 / cuota 03
         $this->assertEqualsWithDelta(100.0, $modelo->casilla('01'), 0.001);
         $this->assertEqualsWithDelta(4.0, $modelo->casilla('03'), 0.001);
+         // 0% -> base 150
+        $this->assertEqualsWithDelta(510.0, $modelo->casilla('150'), 0.001);
 
         // total devengado (casilla 27) = 210 + 50 + 4
         $this->assertEqualsWithDelta(264.0, $modelo->casilla('27'), 0.001);


### PR DESCRIPTION
Se corrige el tratamiento de operaciones con IVA al 0% en el Modelo 303, tanto en ventas como en compras.

En FacturaScripts existe la cuenta especial `IVAREX` para operaciones exentas de venta, pero para que se use correctamente es necesario que la subcuenta de IVA del 0% correspondiente esté marcada como cuenta especial. Si no lo está, una venta con IVA al 0% puede quedar como `IVAREP` genérico y no asignarse a la casilla correspondiente.

### Cambios realizados

Se añade el tratamiento explícito del tipo de IVA `0%` en:

* `IVAREP`: las ventas al 0% se llevan a la casilla `150`, igual que las operaciones exentas (`IVAREX`).
* `IVASOP`: las compras al 0% se reconocen como caso contemplado para evitar avisos del plugin, pero no se llevan a ninguna casilla deducible, ya que no generan cuota soportada.

De esta forma, el Modelo 303 contempla correctamente esta casuística tanto si el usuario configura una cuenta especial de exentas como si deja la subcuenta de manera genérica.

Tal y como ya estaba antes en el modelo, se mantiene contemplado `IVASEX` como posible cuenta especial de compras exentas, que aunque actualmente no exista esa cuenta especial de serie en FacturaScripts, para evitar avisos si en el futuro se añade de manera similar en el core o si alguien la configura manualmente para su diferenciación.
